### PR TITLE
Support numeric log-levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To keep the code base and the API simple, zerolog focuses on JSON logging only. 
 * `context.Context` integration
 * `net/http` helpers
 * Pretty logging for development
+* Numeric log levels
 
 ## Usage
 
@@ -280,6 +281,10 @@ Some settings can be changed and will by applied to all loggers:
 	// using the Dur method.
 * `DurationFieldUnit`: Sets the unit of the fields added by `Dur` (default: `time.Millisecond`).
 * `DurationFieldInteger`: If set to true, `Dur` fields are formatted as integers instead of floats.
+* `LogLevelFlags`: If the `LogLevelNumeric` bit is set to true, the log level
+  field is emitted as a decimal integer.  Additionally, if the `LogLevelBunyan`
+  bit is set use [Bunyan](https://www.npmjs.com/package/bunyan#levels)'s numeric
+  log level values.
 
 ## Field Types
 

--- a/globals.go
+++ b/globals.go
@@ -3,6 +3,20 @@ package zerolog
 import "time"
 import "sync/atomic"
 
+// LogLevelFlag is a bitmask representing flags
+type LogLevelFlag uint
+
+const (
+	// LogLevelNumeric emits an integer for the log level instead of a string.
+	// The default is to emit a string.
+	LogLevelNumeric LogLevelFlag = 1 << iota
+
+	// LogLevelBunyan enables Bunyan's numeric error levels if this flag is set.
+	// In order for this feature to be enabled, the LogLevelNumeric bit must also
+	// be set.  https://www.npmjs.com/package/bunyan#levels
+	LogLevelBunyan
+)
+
 var (
 	// TimestampFieldName is the field name used for the timestamp field.
 	TimestampFieldName = "time"
@@ -31,6 +45,10 @@ var (
 	// DurationFieldInteger renders Dur fields as integer instead of float if
 	// set to true.
 	DurationFieldInteger = false
+
+	// LogLevelFlags sets the flags controlling the style in which the log level
+	// is emitted.
+	LogLevelFlags LogLevelFlag
 )
 
 var (

--- a/log.go
+++ b/log.go
@@ -323,7 +323,16 @@ func (l Logger) newEvent(level Level, addLevelField bool, done func(string)) *Ev
 		e.buf = json.AppendTime(json.AppendKey(e.buf, TimestampFieldName), TimestampFunc(), TimeFieldFormat)
 	}
 	if addLevelField {
-		e.Str(LevelFieldName, level.String())
+		switch {
+		case LogLevelFlags&LogLevelNumeric != LogLevelNumeric:
+			e.Str(LevelFieldName, level.String())
+		case /*LogLevelFlags&LogLevelNumeric == LogLevelNumeric &&*/ LogLevelFlags&LogLevelBunyan != LogLevelBunyan:
+			e.Uint8(LevelFieldName, uint8(level))
+		case /*LogLevelFlags&LogLevelNumeric == LogLevelNumeric &&*/ LogLevelFlags&LogLevelBunyan == LogLevelBunyan:
+			// Map from zerolog error levels to Bunyan logging levels.
+			// https://www.npmjs.com/package/bunyan#levels
+			e.Uint8(LevelFieldName, uint8(level+2)*10)
+		}
 	}
 	if l.context != nil && len(l.context) > 1 {
 		if len(e.buf) > 1 {


### PR DESCRIPTION
For the sake of compatibility with upstream tools, extend the log level to emit numeric log levels intead of string constants.  Implement as a bitmask flagset.  Expose the flagset as a dedicated type and as a global variable for direct manipulation by callers.