### PR TITLE
Fix tests for Windows.

### DIFF
--- a/syslog_test.go
+++ b/syslog_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package zerolog
 
 import "testing"

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package zerolog
 
 import (


### PR DESCRIPTION
Note: it will be necessary to add new Writer tests (not syslogWriter) for Windows in a new file.