### PR TITLE
Added possibility not to log ts when writing to syslog

### DIFF
--- a/console.go
+++ b/console.go
@@ -35,6 +35,7 @@ var consoleBufPool = sync.Pool{
 type ConsoleWriter struct {
 	Out     io.Writer
 	NoColor bool
+	Syslog  bool
 }
 
 func (w ConsoleWriter) Write(p []byte) (n int, err error) {
@@ -53,10 +54,16 @@ func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 		}
 		level = strings.ToUpper(l)[0:4]
 	}
-	fmt.Fprintf(buf, "%s |%s| %s",
-		colorize(event[TimestampFieldName], cDarkGray, !w.NoColor),
-		colorize(level, lvlColor, !w.NoColor),
-		colorize(event[MessageFieldName], cReset, !w.NoColor))
+	if !w.Syslog {
+		fmt.Fprintf(buf, "%s |%s| %s",
+			colorize(event[TimestampFieldName], cDarkGray, !w.NoColor),
+			colorize(level, lvlColor, !w.NoColor),
+			colorize(event[MessageFieldName], cReset, !w.NoColor))
+	} else {
+		fmt.Fprintf(buf, "|%s| %s",
+			colorize(level, lvlColor, !w.NoColor),
+			colorize(event[MessageFieldName], cReset, !w.NoColor))
+	}
 	fields := make([]string, 0, len(event))
 	for field := range event {
 		switch field {


### PR DESCRIPTION
Hi. I use ConsoleWriter for writing to syslog

According to syslog spec 'https://tools.ietf.org/html/rfc5424#section-6.2.3.1' syslog always writes Timestamp as zerolog does.
After all, I get such kind of log messages:
```
myhostname 1512851215:048 2017-12-09T23:26:48.287291+03:00 host daemon_name[32727]: 2017-12-09T23:26:48+03:00 |DEBU| Starting daemon_name
```

When I do not use logger.With().Timestamp(), I get <nil> instead of TS.

This pullrequest allows to disable TS writing to syslog when Syslog flag is set.