### PR TITLE
Update for Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: go
 go:
-- 1.7
-- 1.8
-- 1.9
-- tip
+- "1.7"
+- "1.8"
+- "1.9"
+- "1.10"
+- "master"
 matrix:
   allow_failures:
-      - go: tip
+      - go: "master"
 script:
   go test -v -race -cpu=1,2,4 -bench . -benchmem ./...

--- a/internal/json/string_test.go
+++ b/internal/json/string_test.go
@@ -53,7 +53,7 @@ var encodeStringTests = []struct {
 	{"emoji \u2764\ufe0f!", `"emoji ❤️!"`},
 }
 
-func TestappendString(t *testing.T) {
+func TestAppendString(t *testing.T) {
 	for _, tt := range encodeStringTests {
 		b := AppendString([]byte{}, tt.in)
 		if got, want := string(b), tt.out; got != want {
@@ -62,7 +62,7 @@ func TestappendString(t *testing.T) {
 	}
 }
 
-func TestappendBytes(t *testing.T) {
+func TestAppendBytes(t *testing.T) {
 	for _, tt := range encodeStringTests {
 		b := AppendBytes([]byte{}, []byte(tt.in))
 		if got, want := string(b), tt.out; got != want {
@@ -108,7 +108,7 @@ func TestStringBytes(t *testing.T) {
 	}
 }
 
-func BenchmarkappendString(b *testing.B) {
+func BenchmarkAppendString(b *testing.B) {
 	tests := map[string]string{
 		"NoEncoding":       `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
 		"EncodingFirst":    `"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
@@ -128,7 +128,7 @@ func BenchmarkappendString(b *testing.B) {
 	}
 }
 
-func BenchmarkappendBytes(b *testing.B) {
+func BenchmarkAppendBytes(b *testing.B) {
 	tests := map[string]string{
 		"NoEncoding":       `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
 		"EncodingFirst":    `"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,

--- a/log/log_example_test.go
+++ b/log/log_example_test.go
@@ -102,7 +102,7 @@ func ExampleFatal() {
 
 // This example uses command-line flags to demonstrate various outputs
 // depending on the chosen log level.
-func Example_LevelFlag() {
+func Example() {
 	setup()
 	debug := flag.Bool("debug", false, "sets log level to debug")
 


### PR DESCRIPTION
* add Go 1.10 to `.travis.yml`.
* add quotes to Go versions in `.travis.yml`, because unquoted `1.10` is interpreted
as Go `1.1`
* change `.travis.yml` references from `tip` to `master`. `tip` is a legacy reference coming from the days when the Go project used mercurial instead of git
* fix `go vet` issues, since `go test` now runs vet in parallel
  * change `Example_LevelFlag` to `Example`