### PR TITLE
Mention fields duplication caveat in documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,3 +476,18 @@ Log a static string, without any context or `printf`-style templating:
 | logrus | 1244 ns/op | 1505 B/op | 27 allocs/op |
 | apex/log | 2751 ns/op | 584 B/op | 11 allocs/op |
 | log15 | 5181 ns/op | 1592 B/op | 26 allocs/op |
+
+## Caveats
+
+There is no fields deduplication out-of-the-box.
+Using the same key multiple times creates new key in final JSON each time.
+
+```go
+logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+logger.Info().
+       Timestamp().
+       Msg("dup")
+// Output: {"level":"info","time":1494567715,"time":1494567715,"message":"dup"}
+```
+
+However, it’s not a big deal though as JSON accepts dup keys, the last one prevails.

--- a/context.go
+++ b/context.go
@@ -277,6 +277,8 @@ var th = timestampHook{}
 
 // Timestamp adds the current local time as UNIX timestamp to the logger context with the "time" key.
 // To customize the key name, change zerolog.TimestampFieldName.
+//
+// NOTE: It won't dedupe the "time" key if the *Context has one already.
 func (c Context) Timestamp() Context {
 	c.l = c.l.Hook(th)
 	return c

--- a/event.go
+++ b/event.go
@@ -499,6 +499,9 @@ func (e *Event) Floats64(key string, f []float64) *Event {
 
 // Timestamp adds the current local time as UNIX timestamp to the *Event context with the "time" key.
 // To customize the key name, change zerolog.TimestampFieldName.
+//
+// NOTE: It won't dedupe the "time" key if the *Event (or *Context) has one
+// already.
 func (e *Event) Timestamp() *Event {
 	if e == nil {
 		return e

--- a/log.go
+++ b/log.go
@@ -82,6 +82,20 @@
 //     log.Warn().Msg("")
 //     // Output: {"level":"warn","severity":"warn"}
 //
+//
+// Caveats
+//
+// There is no fields deduplication out-of-the-box.
+// Using the same key multiple times creates new key in final JSON each time.
+//
+//     logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+//     logger.Info().
+//            Timestamp().
+//            Msg("dup")
+//     // Output: {"level":"info","time":1494567715,"time":1494567715,"message":"dup"}
+//
+// However, it’s not a big deal though as JSON accepts dup keys,
+// the last one prevails.
 package zerolog
 
 import (


### PR DESCRIPTION
From #40

>Is there a way to capture log entry timestamp early without timestamps duplication?

>No there is not, it’s part of the trick zerolog is doing to be super fast. It’s not a big deal though as JSON accepts dup keys, the last one prevails. It’s not clean though, I understand.

This PR adds mentions about fields duplication caveat in docs.
