### PR TITLE
Make GlobalLevel a public function

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -49,7 +49,8 @@ func SetGlobalLevel(l Level) {
 	atomic.StoreUint32(gLevel, uint32(l))
 }
 
-func globalLevel() Level {
+// GlobalLevel returns the current global log level
+func GlobalLevel() Level {
 	return Level(atomic.LoadUint32(gLevel))
 }
 

--- a/log.go
+++ b/log.go
@@ -366,7 +366,7 @@ func (l *Logger) newEvent(level Level, done func(string)) *Event {
 
 // should returns true if the log event should be logged.
 func (l *Logger) should(lvl Level) bool {
-	if lvl < l.level || lvl < globalLevel() {
+	if lvl < l.level || lvl < GlobalLevel() {
 		return false
 	}
 	if l.sampler != nil && !samplingDisabled() {


### PR DESCRIPTION
In our case we remember the current log level after every switch it, so we need a public global log level :)