### PR TITLE
Remove full path from caller file, for improved security

### DIFF
--- a/event.go
+++ b/event.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"strings"
 )
 
 var eventPool = &sync.Pool{
@@ -600,6 +601,10 @@ func (e *Event) caller(skip int) *Event {
 	_, file, line, ok := runtime.Caller(skip)
 	if !ok {
 		return e
+	}
+	slash := strings.LastIndex(file, "/")
+	if slash >= 0 {
+		file = file[slash+1:]
 	}
 	e.buf = enc.AppendString(enc.AppendKey(e.buf, CallerFieldName), file+":"+strconv.Itoa(line))
 	return e

--- a/log_test.go
+++ b/log_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"testing"
 	"time"
+	"strings"
 )
 
 func TestLog(t *testing.T) {
@@ -99,7 +100,11 @@ func TestWith(t *testing.T) {
 		Float64("float64", 12.30303).
 		Time("time", time.Time{})
 	_, file, line, _ := runtime.Caller(0)
-	caller := fmt.Sprintf("%s:%d", file, line+3)
+	slash := strings.LastIndex(file, "/")
+	if slash >= 0 {
+		file = file[slash+1:]
+	}
+	caller := fmt.Sprintf("%s:%d", file, line+7)
 	log := ctx.Caller().Logger()
 	log.Log().Msg("")
 	if got, want := decodeIfBinaryToString(out.Bytes()), `{"string":"foo","bytes":"bar","hex":"12ef","json":{"some":"json"},"error":"some error","bool":true,"int":1,"int8":2,"int16":3,"int32":4,"int64":5,"uint":6,"uint8":7,"uint16":8,"uint32":9,"uint64":10,"float32":11.101,"float64":12.30303,"time":"0001-01-01T00:00:00Z","caller":"`+caller+`"}`+"\n"; got != want {
@@ -169,7 +174,11 @@ func TestFields(t *testing.T) {
 	log := New(out)
 	now := time.Now()
 	_, file, line, _ := runtime.Caller(0)
-	caller := fmt.Sprintf("%s:%d", file, line+3)
+	slash := strings.LastIndex(file, "/")
+	if slash >= 0 {
+		file = file[slash+1:]
+	}
+	caller := fmt.Sprintf("%s:%d", file, line+7)
 	log.Log().
 		Caller().
 		Str("string", "foo").


### PR DESCRIPTION
Currently Caller print the absolute path, which usually contains home directory which exposes username of the developer/CI. I added removal of the path, similar to what golang/glog does.
Before:
```
{"level":"info","caller":"/home/<username>/go/src/runtimetest/main.go:25","time":"2018-05-19T09:01:19+04:30"}
```
After:
```
{"level":"info","caller":"main.go:25","time":"2018-05-19T09:02:50+04:30"}
```