### PR TITLE
Diode module Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,10 +298,9 @@ log.Logger = log.With().Str("foo", "bar").Logger()
 If your writer might be slow or not thread-safe and you need your log producers to never get slowed down by a slow writer, you can use a `diode.Writer` as follow:
 
 ```go
-d := diodes.NewManyToOne(1000, diodes.AlertFunc(func(missed int) {
-    fmt.Printf("Dropped %d messages\n", missed)
-}))
-w := diode.NewWriter(os.Stdout, d, 10*time.Millisecond)
+wr := diode.NewWriter(os.Stdout, 1000, 10*time.Millisecond, func(missed int) {
+		fmt.Printf("Logger Dropped %d messages", missed)
+	})
 log := zerolog.New(w)
 log.Print("test")
 ```

--- a/diode/diode.go
+++ b/diode/diode.go
@@ -35,10 +35,11 @@ type Writer struct {
 //
 // Use a diode.Writer when
 //
-//     w := diode.NewWriter(w, 1000, 10 * time.Millisecond, func(missed int) {
+//     wr := diode.NewWriter(w, 1000, 10 * time.Millisecond, func(missed int) {
 //         log.Printf("Dropped %d messages", missed)
 //     })
-//     log := zerolog.New(w)
+//     log := zerolog.New(wr)
+//
 //
 // See code.cloudfoundry.org/go-diodes for more info on diode.
 func NewWriter(w io.Writer, size int, poolInterval time.Duration, f Alerter) Writer {


### PR DESCRIPTION
- README.md example was pre- 77db4b4f3 commit ( Embed the diode lib to avoid test dependencies ) and it was not working

- GoDoc for diode.NewWriter had a ambiguity: assignign a new variable w, but w was a parameter in the function.