### PR TITLE
replace ErrorMarshalFunc with AppendErrorFunc

### DIFF
--- a/array.go
+++ b/array.go
@@ -73,22 +73,7 @@ func (a *Array) Hex(val []byte) *Array {
 
 // Err serializes and appends the err to the array.
 func (a *Array) Err(err error) *Array {
-	marshaled := ErrorMarshalFunc(err)
-	switch m := marshaled.(type) {
-	case LogObjectMarshaler:
-		e := newEvent(nil, 0)
-		e.buf = e.buf[:0]
-		e.appendObject(m)
-		a.buf = append(enc.AppendArrayDelim(a.buf), e.buf...)
-		eventPool.Put(e)
-	case error:
-		a.buf = enc.AppendString(enc.AppendArrayDelim(a.buf), m.Error())
-	case string:
-		a.buf = enc.AppendString(enc.AppendArrayDelim(a.buf), m)
-	default:
-		a.buf = enc.AppendInterface(enc.AppendArrayDelim(a.buf), m)
-	}
-
+	a.buf = AppendErrorFunc(enc, enc.AppendArrayDelim(a.buf), err)
 	return a
 }
 

--- a/encoder.go
+++ b/encoder.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-type encoder interface {
+type Encoder interface {
 	AppendArrayDelim(dst []byte) []byte
 	AppendArrayEnd(dst []byte) []byte
 	AppendArrayStart(dst []byte) []byte

--- a/encoder_cbor.go
+++ b/encoder_cbor.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	_ encoder = (*cbor.Encoder)(nil)
+	_ Encoder = (*cbor.Encoder)(nil)
 
 	enc = cbor.Encoder{}
 )

--- a/encoder_json.go
+++ b/encoder_json.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	_ encoder = (*json.Encoder)(nil)
+	_ Encoder = (*json.Encoder)(nil)
 
 	enc = json.Encoder{}
 )

--- a/fields.go
+++ b/fields.go
@@ -29,39 +29,11 @@ func appendFields(dst []byte, fields map[string]interface{}) []byte {
 		case []byte:
 			dst = enc.AppendBytes(dst, val)
 		case error:
-			marshaled := ErrorMarshalFunc(val)
-			switch m := marshaled.(type) {
-			case LogObjectMarshaler:
-				e := newEvent(nil, 0)
-				e.buf = e.buf[:0]
-				e.appendObject(m)
-				dst = append(dst, e.buf...)
-				eventPool.Put(e)
-			case error:
-				dst = enc.AppendString(dst, m.Error())
-			case string:
-				dst = enc.AppendString(dst, m)
-			default:
-				dst = enc.AppendInterface(dst, m)
-			}
+			dst = AppendErrorFunc(enc, dst, val)
 		case []error:
 			dst = enc.AppendArrayStart(dst)
 			for i, err := range val {
-				marshaled := ErrorMarshalFunc(err)
-				switch m := marshaled.(type) {
-				case LogObjectMarshaler:
-					e := newEvent(nil, 0)
-					e.buf = e.buf[:0]
-					e.appendObject(m)
-					dst = append(dst, e.buf...)
-					eventPool.Put(e)
-				case error:
-					dst = enc.AppendString(dst, m.Error())
-				case string:
-					dst = enc.AppendString(dst, m)
-				default:
-					dst = enc.AppendInterface(dst, m)
-				}
+				dst = AppendErrorFunc(enc, dst, err)
 
 				if i < (len(val) - 1) {
 					enc.AppendArrayDelim(dst)

--- a/log_test.go
+++ b/log_test.go
@@ -547,35 +547,17 @@ func TestErrorMarshalFunc(t *testing.T) {
 	}
 	out.Reset()
 
-	// test overriding the ErrorMarshalFunc
-	originalErrorMarshalFunc := ErrorMarshalFunc
+	// test overriding the AppendErrorFunc
+	originalAppendErrorFunc := AppendErrorFunc
 	defer func(){
-		ErrorMarshalFunc = originalErrorMarshalFunc
+		AppendErrorFunc = originalAppendErrorFunc
 	}()
 
-	ErrorMarshalFunc = func(err error) interface{} {
-		return err.Error() + ": marshaled string"
+	AppendErrorFunc = func(encoder Encoder, buf []byte, err error) []byte {
+		return encoder.AppendString(buf, err.Error() + ": marshaled string")
 	}
 	log.Log().Err(errors.New("err")).Msg("msg")
 	if got, want := decodeIfBinaryToString(out.Bytes()), `{"error":"err: marshaled string","message":"msg"}`+"\n"; got != want {
-		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
-	}
-
-	out.Reset()
-	ErrorMarshalFunc = func(err error) interface{} {
-		return errors.New(err.Error() + ": new error")
-	}
-	log.Log().Err(errors.New("err")).Msg("msg")
-	if got, want := decodeIfBinaryToString(out.Bytes()), `{"error":"err: new error","message":"msg"}`+"\n"; got != want {
-		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
-	}
-
-	out.Reset()
-	ErrorMarshalFunc = func(err error) interface{} {
-		return loggableError{err}
-	}
-	log.Log().Err(errors.New("err")).Msg("msg")
-	if got, want := decodeIfBinaryToString(out.Bytes()), `{"error":{"message":"err: loggableError"},"message":"msg"}`+"\n"; got != want {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
 }


### PR DESCRIPTION
The ErrorMarshalFunc change that got merged recently introduced a lot of code bloat/repetition and had one big drawback: to implement custom serialization of errors that did not implement the `LogObjectMarshaler` you had to wrap the error in an implementor `LogObjectMarshaler`.

This can be avoided if the error marshalling function would work on a lower level (with encoder directly). It would also reduce the code bloat that was the result of the fact we needed to work with different APIs (context, event, array...) as we now work only with the encoder.

I thought of this change yesterday, but didn't manage to include it in the previous PR. :)