### PR TITLE
Allow devs to change the width of the logging level column in consolewriter

### DIFF
--- a/console.go
+++ b/console.go
@@ -31,8 +31,9 @@ var consoleBufPool = sync.Pool{
 	},
 }
 
-// Define the width of the level column, either trim or pad to width, 0 - don't trim or pad.
-var LevelWidth = 4
+// LevelWidth defines the desired character width of the log level column.
+// Default 0 does not trim or pad (variable width based level text, e.g. "INFO" or "ERROR")
+var LevelWidth = 0
 
 // ConsoleWriter reads a JSON object per write operation and output an
 // optionally colored human readable version on the Out writer.
@@ -60,10 +61,11 @@ func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 		}
 		level = strings.ToUpper(l)
 		if LevelWidth > 0 {
-			for i := len(level); i < LevelWidth; i++ {
-				level += ` `
+			if padding := LevelWidth - len(level); padding > 0 {
+				level += strings.Repeat(" ", padding)
+			} else {
+				level = level[0:LevelWidth]
 			}
-			level = level[0:LevelWidth]
 		}
 	}
 	fmt.Fprintf(buf, "%s |%s| %s",

--- a/console.go
+++ b/console.go
@@ -31,6 +31,9 @@ var consoleBufPool = sync.Pool{
 	},
 }
 
+// Define the width of the level column, either trim or pad to width, 0 - don't trim or pad.
+var LevelWidth = 4
+
 // ConsoleWriter reads a JSON object per write operation and output an
 // optionally colored human readable version on the Out writer.
 type ConsoleWriter struct {
@@ -55,7 +58,13 @@ func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 		if !w.NoColor {
 			lvlColor = levelColor(l)
 		}
-		level = strings.ToUpper(l)[0:4]
+		level = strings.ToUpper(l)
+		if LevelWidth > 0 {
+			for i := len(level); i < LevelWidth; i++ {
+				level += ` `
+			}
+			level = level[0:LevelWidth]
+		}
 	}
 	fmt.Fprintf(buf, "%s |%s| %s",
 		colorize(formatTime(event[TimestampFieldName]), cDarkGray, !w.NoColor),


### PR DESCRIPTION
In the console writer, rather than always truncating the log Level to 4 characters, allow the dev to set their own value, padding or trimming as necessary.  Setting a LevelWidth of 0 leaves it as-is without any padding or trimming.

This adds a little flexibility for people who do not like the present way that these fields are truncated for 'DEBU' and 'ERRO'.