### PR TITLE
Add note for default writing to os.Stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ func main() {
 
 // Output: {"time":1516134303,"level":"debug","message":"hello world"}
 ```
-
+> Note: By default log writes to `os.Stderr`  
 > Note: The default log level for `log.Print` is *debug*
 
 ### Contextual Logging


### PR DESCRIPTION
Documents the default behaviour of writing to `stderr` (see https://github.com/rs/zerolog/issues/96)