### PR TITLE
Increased CallerSkipFrameCount in Msgf

### DIFF
--- a/event.go
+++ b/event.go
@@ -102,6 +102,7 @@ func (e *Event) Msgf(format string, v ...interface{}) {
 	if e == nil {
 		return
 	}
+	CallerSkipFrameCount++
 	e.msg(fmt.Sprintf(format, v...))
 }
 


### PR DESCRIPTION
`Msgf` function call `Msg` which add one more hop. CallerSkipFrameCount needs to increase by 1,  to handle that hop.