### PR TITLE
Fix sub-logger by context example

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ hooked.Warn().Msg("")
 ### Pass a sub-logger by context
 
 ```go
-ctx := log.With("component", "module").Logger().WithContext(ctx)
+ctx := log.With().Str("component", "module").Logger().WithContext(ctx)
 
 log.Ctx(ctx).Info().Msg("hello world")
 


### PR DESCRIPTION
Not quite sure but looks like the example is using the wrong API.