### PR TITLE
Don't call panic() and os.Exit(1) on .WithLevel()

### DIFF
--- a/log.go
+++ b/log.go
@@ -321,9 +321,9 @@ func (l *Logger) WithLevel(level Level) *Event {
 	case ErrorLevel:
 		return l.Error()
 	case FatalLevel:
-		return l.Fatal()
+		return l.newEvent(FatalLevel, nil)
 	case PanicLevel:
-		return l.Panic()
+		return l.newEvent(PanicLevel, nil)
 	case NoLevel:
 		return l.Log()
 	case Disabled:

--- a/log.go
+++ b/log.go
@@ -292,22 +292,24 @@ func (l *Logger) Error() *Event {
 }
 
 // Fatal starts a new message with fatal level. The os.Exit(1) function
-// is called by the Msg method.
+// is called by the Msg method, which terminates the program immediately.
 //
 // You must call Msg on the returned event in order to send the event.
 func (l *Logger) Fatal() *Event {
 	return l.newEvent(FatalLevel, func(msg string) { os.Exit(1) })
 }
 
-// Panic starts a new message with panic level. The message is also sent
-// to the panic function.
+// Panic starts a new message with panic level. The panic() function
+// is called by the Msg method, which stops the ordinary flow of a goroutine.
 //
 // You must call Msg on the returned event in order to send the event.
 func (l *Logger) Panic() *Event {
 	return l.newEvent(PanicLevel, func(msg string) { panic(msg) })
 }
 
-// WithLevel starts a new message with level.
+// WithLevel starts a new message with level. Unlike Fatal and Panic
+// methods, WithLevel does not terminate the program or stop the ordinary
+// flow of a gourotine when used with their respective levels.
 //
 // You must call Msg on the returned event in order to send the event.
 func (l *Logger) WithLevel(level Level) *Event {


### PR DESCRIPTION
## Rationale:

I'd like to be able to set `PANIC` or `FATAL` levels explicitly via `logger.WithLevel()`, without having to exit my program.

## Current state:
`logger.Fatal()` calls `os.Exit(1)` .. that's obvious and expected
`logger.Panic()` calls `panic()` .. that's obvious and expected

`logger.WithLevel(zerolog.FatalLevel)` calls `os.Exit(1)` too, which feels wrong
`logger.WithLevel(zerolog.PanicLevel)`  calls `panic()` too, which feels wrong

## Proposal:
I'd like to be able to set an explicit log level via `logger.WithLevel(lvl)` without program flow side effects.