### PR TITLE
Fix the ConsoleWriter default parts order

### DIFF
--- a/console.go
+++ b/console.go
@@ -38,11 +38,13 @@ var (
 
 	consoleDefaultTimeFormat = time.Kitchen
 	consoleDefaultFormatter  = func(i interface{}) string { return fmt.Sprintf("%s", i) }
-	consoleDefaultPartsOrder = []string{
-		TimestampFieldName,
-		LevelFieldName,
-		CallerFieldName,
-		MessageFieldName,
+	consoleDefaultPartsOrder = func() []string {
+		return []string{
+			TimestampFieldName,
+			LevelFieldName,
+			CallerFieldName,
+			MessageFieldName,
+		}
 	}
 
 	consoleNoColor    = false
@@ -82,7 +84,7 @@ func NewConsoleWriter(options ...func(w *ConsoleWriter)) ConsoleWriter {
 	w := ConsoleWriter{
 		Out:        os.Stdout,
 		TimeFormat: consoleDefaultTimeFormat,
-		PartsOrder: consoleDefaultPartsOrder,
+		PartsOrder: consoleDefaultPartsOrder(),
 	}
 
 	for _, opt := range options {
@@ -95,7 +97,7 @@ func NewConsoleWriter(options ...func(w *ConsoleWriter)) ConsoleWriter {
 // Write transforms the JSON input with formatters and appends to w.Out.
 func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 	if w.PartsOrder == nil {
-		w.PartsOrder = consoleDefaultPartsOrder
+		w.PartsOrder = consoleDefaultPartsOrder()
 	}
 	if w.TimeFormat == "" && consoleTimeFormat != consoleDefaultTimeFormat {
 		consoleTimeFormat = consoleDefaultTimeFormat


### PR DESCRIPTION
In order to prevent incorrect output when somebody uses a different name eg. for the "MessageFieldName", the `consoleDefaultPartsOrder` variable has been switched to a function, which is called in `Write()`, in order to pick up the custom name.

Example:

```
zerolog.MessageFieldName = "msg"
output := zerolog.ConsoleWriter{Out: os.Stdout}
logger := zerolog.New(output).With().Timestamp().Logger()
logger.Info().Msg("this message won't show")
```

Related: rs/zerolog#92