### PR TITLE
Fix race condition in ConsoleWriter

### DIFF
--- a/console.go
+++ b/console.go
@@ -36,6 +36,7 @@ var (
 		},
 	}
 
+	mu                       sync.Mutex
 	consoleDefaultTimeFormat = time.Kitchen
 	consoleDefaultFormatter  = func(i interface{}) string { return fmt.Sprintf("%s", i) }
 	consoleDefaultPartsOrder = func() []string {
@@ -96,6 +97,7 @@ func NewConsoleWriter(options ...func(w *ConsoleWriter)) ConsoleWriter {
 
 // Write transforms the JSON input with formatters and appends to w.Out.
 func (w ConsoleWriter) Write(p []byte) (n int, err error) {
+	mu.Lock()
 	if w.PartsOrder == nil {
 		w.PartsOrder = consoleDefaultPartsOrder()
 	}
@@ -111,6 +113,7 @@ func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 	if w.NoColor == true && consoleNoColor != w.NoColor {
 		consoleNoColor = w.NoColor
 	}
+	mu.Unlock()
 
 	var buf = consoleBufPool.Get().(*bytes.Buffer)
 	defer consoleBufPool.Put(buf)


### PR DESCRIPTION
When the ConsoleWriter has been customized, the operations accessing
variables in the `Write()` method had race condition, as reported in
https://github.com/rs/zerolog/pull/92#issuecomment-444038726.

A simple mutex lock has been added around the section.

Example code:

```go
package main

import (
	"fmt"
	"os"
	"sync"
	"time"

	"github.com/rs/zerolog"
	"github.com/rs/zerolog/log"
)

func main() {
	var wg sync.WaitGroup

	log.Logger = log.With().Timestamp().Logger().Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})

	// output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
	// log := zerolog.New(output).With().Timestamp().Logger()

	for i := 0; i < 10000; i++ {
		wg.Add(1)

		go func(i int) {
			defer wg.Done()
			log.Info().Str("foo", "bar").Msg(fmt.Sprintf("Hello from goroutine %d", i))
		}(i)
	}

	wg.Wait()
}
```