### PR TITLE
Add support for stack trace extration of error fields

### DIFF
--- a/context.go
+++ b/context.go
@@ -379,3 +379,17 @@ func (c Context) MACAddr(key string, ha net.HardwareAddr) Context {
 	c.l.context = enc.AppendMACAddr(enc.AppendKey(c.l.context, key), ha)
 	return c
 }
+
+type stackTraceHook struct{}
+
+func (sh stackTraceHook) Run(e *Event, level Level, msg string) {
+	e.Stack()
+}
+
+var sh = callerHook{}
+
+// Stack enables stack trace printing for the error passed to Err().
+func (c Context) Stack() Context {
+	c.l = c.l.Hook(sh)
+	return c
+}

--- a/event.go
+++ b/event.go
@@ -30,6 +30,7 @@ type Event struct {
 	w     LevelWriter
 	level Level
 	done  func(msg string)
+	stack bool   // enable error stack trace
 	ch    []Hook // hooks from context
 }
 
@@ -316,6 +317,16 @@ func (e *Event) Errs(key string, errs []error) *Event {
 // To customize the key name, change zerolog.ErrorFieldName.
 func (e *Event) Err(err error) *Event {
 	return e.AnErr(ErrorFieldName, err)
+}
+
+// Stack enables stack trace printing for the error passed to Err().
+//
+// ErrorStackMarshaler must be set for this method to do something.
+func (e *Event) Stack() *Event {
+	if e != nil {
+		e.stack = true
+	}
+	return e
 }
 
 // Bool adds the field key with val as a bool to the *Event context.

--- a/globals.go
+++ b/globals.go
@@ -22,6 +22,13 @@ var (
 	// CallerSkipFrameCount is the number of stack frames to skip to find the caller.
 	CallerSkipFrameCount = 2
 
+	// ErrorStackFieldName is the field name used for error stacks.
+	ErrorStackFieldName = "stack"
+
+	// ErrorStackMarshaler extract the stack from err if any, and returns it as
+	// a marshaled JSON.
+	ErrorStackMarshaler func(err error) []byte
+
 	// TimeFieldFormat defines the time format of the Time field type.
 	// If set to an empty string, the time is formatted as an UNIX timestamp
 	// as integer.

--- a/pkgerrors/stacktrace.go
+++ b/pkgerrors/stacktrace.go
@@ -1,0 +1,66 @@
+package pkgerrors
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/internal/json"
+)
+
+var (
+	StackSourceFileName     = "source"
+	StackSourceLineName     = "line"
+	StackSourceFunctionName = "func"
+)
+
+// MarshalStack implements pkg/errors stack trace marshaling.
+//
+//   zerolog.ErrorStackMarshaler = MarshalStack
+func MarshalStack(err error) []byte {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+	var st errors.StackTrace
+	if err, ok := err.(stackTracer); ok {
+		st = err.StackTrace()
+	} else {
+		return nil
+	}
+	return appendJSONStack(make([]byte, 0, 500), st)
+}
+
+func appendJSONStack(dst []byte, st errors.StackTrace) []byte {
+	buf := bytes.NewBuffer(make([]byte, 0, 100))
+	dst = append(dst, '[')
+	for i, frame := range st {
+		if i > 0 {
+			dst = append(dst, ',')
+		}
+
+		dst = append(dst, '{')
+
+		fmt.Fprintf(buf, "%s", frame)
+		dst = json.AppendString(dst, StackSourceFileName)
+		dst = append(dst, ':')
+		dst = json.AppendBytes(dst, buf.Bytes())
+		dst = append(dst, ',')
+		buf.Reset()
+
+		fmt.Fprintf(buf, "%d", frame)
+		dst = json.AppendString(dst, StackSourceLineName)
+		dst = append(dst, ':')
+		dst = json.AppendBytes(dst, buf.Bytes())
+		dst = append(dst, ',')
+		buf.Reset()
+
+		fmt.Fprintf(buf, "%n", frame)
+		dst = json.AppendString(dst, StackSourceFunctionName)
+		dst = append(dst, ':')
+		dst = json.AppendBytes(dst, buf.Bytes())
+
+		dst = append(dst, '}')
+	}
+	dst = append(dst, ']')
+	return dst
+}

--- a/pkgerrors/stacktrace_test.go
+++ b/pkgerrors/stacktrace_test.go
@@ -1,0 +1,26 @@
+package pkgerrors
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+func TestLogStack(t *testing.T) {
+	zerolog.ErrorStackMarshaler = MarshalStack
+
+	out := &bytes.Buffer{}
+	log := zerolog.New(out)
+
+	err := errors.Wrap(errors.New("error message"), "from error")
+	log.Log().Stack().Err(err).Msg("")
+
+	got := out.String()
+	want := `\{"stack":\[\{"source":"stacktrace_test.go","line":"18","func":"TestLogStack"\},.*\],"error":"from error: error message"\}\n`
+	if ok, _ := regexp.MatchString(want, got); !ok {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}


### PR DESCRIPTION
Takes the work done by @rs and @soulne4ny in #35 just re-based against master.

Quite keen for this feature so thought I would try and help get it in :smile: 