### PR TITLE
Added multistack logging -- wip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,11 @@
 module github.com/rs/zerolog
+
+go 1.12
+
+require (
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/pkg/errors v0.8.1
+	github.com/rs/xid v1.2.1
+	github.com/zenazn/goji v0.9.0
+	golang.org/x/tools v0.0.0-20190321154406-ae772f11d294
+)


### PR DESCRIPTION
There is an issue with the way the MarshalStack is implemented right now. It only prints info on the last stack trace -- which is really unhelpful if you have multiple stacks (i.e. you really want to know where the original stack trace came from).

This pull request adds the ability to log all of the stack traces collected by the errors. It is pretty much there, but I've marked as wip because the exact formatting needs to be determined -- probably better to use an inbuilt encoding mechanism of zerolog (instead of json), but I'm not too familiar with the encoding of zerolog... @rs do you have any suggestions? Thanks! 