### PR TITLE
%!S seen when using console writer with NoLevel

### DIFF
--- a/console.go
+++ b/console.go
@@ -321,6 +321,8 @@ func consoleDefaultFormatLevel(noColor bool) Formatter {
 			default:
 				l = colorize("???", colorBold, noColor)
 			}
+		} else if i == nil {
+			l = ""
 		} else {
 			l = strings.ToUpper(fmt.Sprintf("%s", i))[0:3]
 		}

--- a/console_test.go
+++ b/console_test.go
@@ -71,6 +71,7 @@ func TestConsoleLogger(t *testing.T) {
 	})
 }
 
+
 func TestConsoleWriter(t *testing.T) {
 	t.Run("Default field formatter", func(t *testing.T) {
 		buf := &bytes.Buffer{}
@@ -199,6 +200,25 @@ func TestConsoleWriter(t *testing.T) {
 		if actualOutput != expectedOutput {
 			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
 		}
+	})
+
+	t.Run("Write no level", func(t *testing.T) {
+		t.Run("Default field formatter no level", func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			w := zerolog.ConsoleWriter{Out: buf, NoColor:true}
+
+			evt := `{"message" : "Foobar", "foo" : [1, 2, 3], "bar" : true}`
+			_, err := w.Write([]byte(evt))
+			if err != nil {
+				t.Errorf("Unexpected error when writing output: %s", err)
+			}
+
+			expectedOutput := "<nil> Foobar bar=true foo=[1,2,3]\n"
+			actualOutput := buf.String()
+			if actualOutput != expectedOutput {
+				t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
Currently when using the provided console logger with a level of `NoLevel`, you get this sort of output:
`"<nil> %!S Foobar bar=true foo=[1,2,3]\n"`.  I think ideally this should be `"<nil> Foobar bar=true foo=[1,2,3]\n"`

I have created a test case and implemented a proposed fix for this.