### PR TITLE
What: resolve https://github.com/rs/zerolog/issues/159

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.idea
+

--- a/log_test.go
+++ b/log_test.go
@@ -571,6 +571,19 @@ func TestEventTimestamp(t *testing.T) {
 	}
 }
 
+func TestEvent_MsgWithFieldName(t *testing.T) {
+	fieldName := "cost"
+	fieldValue, _ := time.Parse("2006-01-02T15:04:05", "2016-01-02T15:04:05")
+
+	out := &bytes.Buffer{}
+	log := New(out).With().Str("foo", "bar").Logger()
+	log.Log().MsgWithFieldName(fieldName).Msgf("%v", fieldValue)
+
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"foo":"bar","cost":"2016-01-02 15:04:05 +0000 UTC"}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
 func TestOutputWithoutTimestamp(t *testing.T) {
 	ignoredOut := &bytes.Buffer{}
 	out := &bytes.Buffer{}


### PR DESCRIPTION
Why:

  * support custom message field name for event

How:

  * MsgWithFieldName("cost").Msgf("%v", time.Now())