### PR TITLE
Simplify code of Event.msg(msg string)

### DIFF
--- a/event.go
+++ b/event.go
@@ -127,13 +127,8 @@ func (e *Event) Msgf(format string, v ...interface{}) {
 }
 
 func (e *Event) msg(msg string) {
-	if len(e.ch) > 0 {
-		e.ch[0].Run(e, e.level, msg)
-		if len(e.ch) > 1 {
-			for _, hook := range e.ch[1:] {
-				hook.Run(e, e.level, msg)
-			}
-		}
+	for _, hook := range e.ch {
+		hook.Run(e, e.level, msg)
 	}
 	if msg != "" {
 		e.buf = enc.AppendString(enc.AppendKey(e.buf, MessageFieldName), msg)


### PR DESCRIPTION
Simplify the code of `Event.msg(msg string)`,

The test passed after modification.

I also test if it  has an impact on the speed by running `BenchmarkHooks` for three times:


Test Environment:
```
os: darwin
arch: amd64
version: go 1.12.6
```

Before modified:

```
BenchmarkHooks/Nop/Single-4         	50000000	        40.4 ns/op
BenchmarkHooks/Nop/Multi-4          	30000000	        50.8 ns/op
BenchmarkHooks/Simple-4             	20000000	        77.2 ns/op

BenchmarkHooks/Nop/Single-4         	30000000	        40.4 ns/op
BenchmarkHooks/Nop/Multi-4          	30000000	        46.2 ns/op
BenchmarkHooks/Simple-4             	20000000	        78.0 ns/op

BenchmarkHooks/Nop/Single-4         	50000000	        42.1 ns/op
BenchmarkHooks/Nop/Multi-4          	30000000	        45.8 ns/op
BenchmarkHooks/Simple-4             	20000000	        74.9 ns/op
```

After modified:

```
BenchmarkHooks/Nop/Single-4         	30000000	        38.5 ns/op
BenchmarkHooks/Nop/Multi-4          	30000000	        47.2 ns/op
BenchmarkHooks/Simple-4             	20000000	        75.0 ns/op

BenchmarkHooks/Nop/Single-4         	30000000	        39.9 ns/op
BenchmarkHooks/Nop/Multi-4          	30000000	        45.3 ns/op
BenchmarkHooks/Simple-4             	20000000	        77.2 ns/op

BenchmarkHooks/Nop/Single-4         	50000000	        44.3 ns/op
BenchmarkHooks/Nop/Multi-4          	30000000	        44.0 ns/op
BenchmarkHooks/Simple-4             	20000000	        76.4 ns/op
```