### PR TITLE
Allow user to custom order of field in ConsoleWriter

### DIFF
--- a/console.go
+++ b/console.go
@@ -57,6 +57,9 @@ type ConsoleWriter struct {
 	// PartsOrder defines the order of parts in output.
 	PartsOrder []string
 
+	// FieldsOrder defines the order of fields
+	FieldOrder []string
+
 	FormatTimestamp     Formatter
 	FormatLevel         Formatter
 	FormatCaller        Formatter
@@ -117,6 +120,15 @@ func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 	return len(p), err
 }
 
+func (w ConsoleWriter) getFieldsOrders(fields []string) []string {
+	if w.FieldOrder != nil {
+		return w.FieldOrder
+	} else {
+		sort.Strings(fields)
+		return fields
+	}
+}
+
 // writeFields appends formatted key-value pairs to buf.
 func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer) {
 	var fields = make([]string, 0, len(evt))
@@ -127,7 +139,7 @@ func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer
 		}
 		fields = append(fields, field)
 	}
-	sort.Strings(fields)
+	fields = w.getFieldsOrders(fields)
 
 	if len(fields) > 0 {
 		buf.WriteByte(' ')

--- a/console.go
+++ b/console.go
@@ -58,7 +58,7 @@ type ConsoleWriter struct {
 	PartsOrder []string
 
 	// FieldsOrder defines the order of fields
-	FieldOrder []string
+	OrderFields func([]string) []string
 
 	FormatTimestamp     Formatter
 	FormatLevel         Formatter
@@ -120,15 +120,6 @@ func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 	return len(p), err
 }
 
-func (w ConsoleWriter) getFieldsOrders(fields []string) []string {
-	if w.FieldOrder != nil {
-		return w.FieldOrder
-	} else {
-		sort.Strings(fields)
-		return fields
-	}
-}
-
 // writeFields appends formatted key-value pairs to buf.
 func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer) {
 	var fields = make([]string, 0, len(evt))
@@ -139,7 +130,11 @@ func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer
 		}
 		fields = append(fields, field)
 	}
-	fields = w.getFieldsOrders(fields)
+	if w.OrderFields != nil {
+		fields = w.OrderFields(fields)
+	} else {
+		sort.Strings(fields)
+	}
 
 	if len(fields) > 0 {
 		buf.WriteByte(' ')

--- a/console_test.go
+++ b/console_test.go
@@ -121,6 +121,23 @@ func TestConsoleWriter(t *testing.T) {
 		}
 	})
 
+	t.Run("Write fields in custom order", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		w := zerolog.ConsoleWriter{Out: buf, NoColor: true, FieldOrder: []string{"foo", "zero", "do"}}
+
+		d := time.Unix(0, 0).UTC().Format(time.RFC3339)
+		_, err := w.Write([]byte(`{"time": "` + d + `", "level": "debug", "message": "Foobar", "foo": "bar", "do": "that", "zero": "log"}`))
+		if err != nil {
+			t.Errorf("Unexpected error when writing output: %s", err)
+		}
+
+		expectedOutput := "12:00AM DBG Foobar foo=bar zero=log do=that\n"
+		actualOutput := buf.String()
+		if actualOutput != expectedOutput {
+			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
+		}
+	})
+
 	t.Run("Unix timestamp input format", func(t *testing.T) {
 		of := zerolog.TimeFieldFormat
 		defer func() {

--- a/console_test.go
+++ b/console_test.go
@@ -123,7 +123,9 @@ func TestConsoleWriter(t *testing.T) {
 
 	t.Run("Write fields in custom order", func(t *testing.T) {
 		buf := &bytes.Buffer{}
-		w := zerolog.ConsoleWriter{Out: buf, NoColor: true, FieldOrder: []string{"foo", "zero", "do"}}
+		w := zerolog.ConsoleWriter{Out: buf, NoColor: true, OrderFields: func(fields []string) []string {
+			return []string{"foo", "zero", "do"}
+		}}
 
 		d := time.Unix(0, 0).UTC().Format(time.RFC3339)
 		_, err := w.Write([]byte(`{"time": "` + d + `", "level": "debug", "message": "Foobar", "foo": "bar", "do": "that", "zero": "log"}`))

--- a/console_test.go
+++ b/console_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -54,6 +55,23 @@ func ExampleNewConsoleWriter_customFormatters() {
 
 	log.Info().Str("foo", "bar").Msg("Hello World")
 	// Output: <nil> [INFO ] Hello World foo=bar
+}
+
+func ExampleNewConsoleWriter_customOrders() {
+	out := zerolog.NewConsoleWriter(
+		func(w *zerolog.ConsoleWriter) {
+			w.OrderFields = func(strs []string) []string {
+				sort.Sort(sort.Reverse(sort.StringSlice(strs)))
+				return strs
+			}
+		},
+	)
+
+	out.NoColor = true // For testing purposes only
+
+	log := zerolog.New(out)
+	log.Info().Int("echo", 5).Str("foo", "bar").Send()
+	// Output: <nil> INF  foo=bar echo=5
 }
 
 func TestConsoleLogger(t *testing.T) {


### PR DESCRIPTION
As point out in #155. It would be nice to have some control on the order of the output field.

Add example on how to custom field's order. 