### PR TITLE
make sure event.Stack() is called before event.Err()

### DIFF
--- a/context.go
+++ b/context.go
@@ -399,6 +399,7 @@ var sh = stackTraceHook{}
 // Stack enables stack trace printing for the error passed to Err().
 func (c Context) Stack() Context {
 	c.l = c.l.Hook(sh)
+	c.l.stack = true
 	return c
 }
 

--- a/log.go
+++ b/log.go
@@ -181,6 +181,7 @@ type Logger struct {
 	sampler Sampler
 	context []byte
 	hooks   []Hook
+	stack   bool
 }
 
 // New creates a root logger with given output writer. If the output writer implements
@@ -401,6 +402,9 @@ func (l *Logger) newEvent(level Level, done func(string)) *Event {
 	}
 	if l.context != nil && len(l.context) > 0 {
 		e.buf = enc.AppendObjectData(e.buf, l.context)
+	}
+	if l.stack {
+		e.Stack()
 	}
 	return e
 }


### PR DESCRIPTION
This fixes the issue where ```log.Logger = log.With().Stack().Logger()``` does not work due to the hooks being called after ```log.Error().Err(err)```.