### PR TITLE
Add Stringer and Stringers method for *Event  context

### DIFF
--- a/event.go
+++ b/event.go
@@ -241,6 +241,10 @@ func (e *Event) Stringer(key string, val fmt.Stringer) *Event {
 	if e == nil {
 		return e
 	}
+	if val == nil {
+		e.buf = enc.AppendString(enc.AppendKey(e.buf, key), "nil")
+		return e
+	}
 	e.buf = enc.AppendString(enc.AppendKey(e.buf, key), val.String())
 	return e
 }

--- a/event.go
+++ b/event.go
@@ -235,6 +235,26 @@ func (e *Event) Strs(key string, vals []string) *Event {
 	return e
 }
 
+// Stringer adds the field key with val as a string to the *Event context.
+// Use Stringer if possible, because it creates string value in lazy mode.
+func (e *Event) Stringer(key string, val fmt.Stringer) *Event {
+	if e == nil {
+		return e
+	}
+	e.buf = enc.AppendString(enc.AppendKey(e.buf, key), val.String())
+	return e
+}
+
+// Stringers adds the field key with vals as a []string to the *Event context.
+// Use Stringer if possible, because it creates string values in lazy mode.
+func (e *Event) Stringers(key string, vals []fmt.Stringer) *Event {
+	if e == nil {
+		return e
+	}
+	e.buf = enc.AppendStringers(enc.AppendKey(e.buf, key), vals)
+	return e
+}
+
 // Bytes adds the field key with val as a string to the *Event context.
 //
 // Runes outside of normal ASCII ranges will be hex-encoded in the resulting

--- a/event.go
+++ b/event.go
@@ -242,7 +242,7 @@ func (e *Event) Stringer(key string, val fmt.Stringer) *Event {
 		return e
 	}
 	if val == nil {
-		e.buf = enc.AppendString(enc.AppendKey(e.buf, key), "nil")
+		e.buf = enc.AppendInterface(enc.AppendKey(e.buf, key), nil)
 		return e
 	}
 	e.buf = enc.AppendString(enc.AppendKey(e.buf, key), val.String())

--- a/internal/cbor/string.go
+++ b/internal/cbor/string.go
@@ -30,7 +30,11 @@ func (e Encoder) AppendStringers(dst []byte, vals []fmt.Stringer) []byte {
 		dst = appendCborTypePrefix(dst, major, uint64(l))
 	}
 	for _, v := range vals {
-		dst = e.AppendString(dst, v.String())
+		if v == nil {
+			dst = e.AppendString(dst, "nil")
+		} else {
+			dst = e.AppendString(dst, v.String())
+		}
 	}
 	return dst
 }

--- a/internal/cbor/string.go
+++ b/internal/cbor/string.go
@@ -31,7 +31,7 @@ func (e Encoder) AppendStringers(dst []byte, vals []fmt.Stringer) []byte {
 	}
 	for _, v := range vals {
 		if v == nil {
-			dst = e.AppendString(dst, "nil")
+			dst = e.AppendInterface(dst, nil)
 		} else {
 			dst = e.AppendString(dst, v.String())
 		}

--- a/internal/cbor/string.go
+++ b/internal/cbor/string.go
@@ -1,5 +1,7 @@
 package cbor
 
+import "fmt"
+
 // AppendStrings encodes and adds an array of strings to the dst byte array.
 func (e Encoder) AppendStrings(dst []byte, vals []string) []byte {
 	major := majorTypeArray
@@ -12,6 +14,23 @@ func (e Encoder) AppendStrings(dst []byte, vals []string) []byte {
 	}
 	for _, v := range vals {
 		dst = e.AppendString(dst, v)
+	}
+	return dst
+}
+
+// AppendStringers encodes and adds an array of fmt.Stringer to the dst byte array.
+// It allows to make a string lazy
+func (e Encoder) AppendStringers(dst []byte, vals []fmt.Stringer) []byte {
+	major := majorTypeArray
+	l := len(vals)
+	if l <= additionalMax {
+		lb := byte(l)
+		dst = append(dst, byte(major|lb))
+	} else {
+		dst = appendCborTypePrefix(dst, major, uint64(l))
+	}
+	for _, v := range vals {
+		dst = e.AppendString(dst, v.String())
 	}
 	return dst
 }

--- a/internal/json/string.go
+++ b/internal/json/string.go
@@ -1,6 +1,9 @@
 package json
 
-import "unicode/utf8"
+import (
+	"fmt"
+	"unicode/utf8"
+)
 
 const hex = "0123456789abcdef"
 
@@ -23,6 +26,23 @@ func (e Encoder) AppendStrings(dst []byte, vals []string) []byte {
 	if len(vals) > 1 {
 		for _, val := range vals[1:] {
 			dst = e.AppendString(append(dst, ','), val)
+		}
+	}
+	dst = append(dst, ']')
+	return dst
+}
+
+// AppendStringers encodes the input []fmt.Stringer to json and
+// appends the encoded string list to the input byte slice.
+func (e Encoder) AppendStringers(dst []byte, vals []fmt.Stringer) []byte {
+	if len(vals) == 0 {
+		return append(dst, '[', ']')
+	}
+	dst = append(dst, '[')
+	dst = e.AppendString(dst, vals[0].String())
+	if len(vals) > 1 {
+		for _, val := range vals[1:] {
+			dst = e.AppendString(append(dst, ','), val.String())
 		}
 	}
 	dst = append(dst, ']')

--- a/internal/json/string.go
+++ b/internal/json/string.go
@@ -41,7 +41,7 @@ func (e Encoder) AppendStringers(dst []byte, vals []fmt.Stringer) []byte {
 	dst = append(dst, '[')
 
 	if vals[0] == nil {
-		dst = e.AppendString(dst, "nil")
+		dst = e.AppendInterface(dst, nil)
 	} else {
 		dst = e.AppendString(dst, vals[0].String())
 	}

--- a/internal/json/string.go
+++ b/internal/json/string.go
@@ -39,10 +39,20 @@ func (e Encoder) AppendStringers(dst []byte, vals []fmt.Stringer) []byte {
 		return append(dst, '[', ']')
 	}
 	dst = append(dst, '[')
-	dst = e.AppendString(dst, vals[0].String())
+
+	if vals[0] == nil {
+		dst = e.AppendString(dst, "nil")
+	} else {
+		dst = e.AppendString(dst, vals[0].String())
+	}
+
 	if len(vals) > 1 {
 		for _, val := range vals[1:] {
-			dst = e.AppendString(append(dst, ','), val.String())
+			if val == nil {
+				dst = e.AppendString(append(dst, ','), "nil")
+			} else {
+				dst = e.AppendString(append(dst, ','), val.String())
+			}
 		}
 	}
 	dst = append(dst, ']')

--- a/internal/json/string_test.go
+++ b/internal/json/string_test.go
@@ -1,8 +1,36 @@
 package json
 
 import (
+	"fmt"
 	"testing"
 )
+
+type testStringer string
+
+func (t testStringer) String() string {
+	return string(t)
+}
+
+type encodeStringerTestTable struct {
+	in  fmt.Stringer
+	out string
+}
+
+func newTestStringerTable(data []struct {
+	in  string
+	out string
+}) []encodeStringerTestTable {
+	res := make([]encodeStringerTestTable, len(data))
+	for i, t := range data {
+		res[i] = encodeStringerTestTable{
+			in:  testStringer(t.in),
+			out: t.out,
+		}
+	}
+	return res
+}
+
+var encodeStringerTests = newTestStringerTable(encodeStringTests)
 
 var encodeStringTests = []struct {
 	in  string
@@ -68,6 +96,15 @@ func TestAppendString(t *testing.T) {
 		b := enc.AppendString([]byte{}, tt.in)
 		if got, want := string(b), tt.out; got != want {
 			t.Errorf("appendString(%q) = %#q, want %#q", tt.in, got, want)
+		}
+	}
+}
+
+func TestAppendStringer(t *testing.T) {
+	for _, tt := range encodeStringerTests {
+		b := enc.AppendString([]byte{}, tt.in.String())
+		if got, want := string(b), tt.out; got != want {
+			t.Errorf("appendString(%q) = %#q, want %#q", tt.in.String(), got, want)
 		}
 	}
 }


### PR DESCRIPTION
Hi.
I made an implementation for adding values as a fmt.Stringer interface. It allows don't create new strings from struct in many cases and do it only if your log level and other conditions require it.