### PR TITLE
Add Unix time format for microseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ Some settings can be changed and will by applied to all loggers:
 * `zerolog.LevelFieldName`: Can be set to customize level field name.
 * `zerolog.MessageFieldName`: Can be set to customize message field name.
 * `zerolog.ErrorFieldName`: Can be set to customize `Err` field name.
-* `zerolog.TimeFieldFormat`: Can be set to customize `Time` field value formatting. If set with `zerolog.TimeFormatUnix` or `zerolog.TimeFormatUnixMs`, times are formated as UNIX timestamp.
+* `zerolog.TimeFieldFormat`: Can be set to customize `Time` field value formatting. If set with `zerolog.TimeFormatUnix`, `zerolog.TimeFormatUnixMs` or `zerolog.timeFormatUnixMicro`, times are formated as UNIX timestamp.
 * `zerolog.DurationFieldUnit`: Can be set to customize the unit for time.Duration type fields added by `Dur` (default: `time.Millisecond`).
 * `zerolog.DurationFieldInteger`: If set to `true`, `Dur` fields are formatted as integers instead of floats (default: `false`). 
 * `zerolog.ErrorHandler`: Called whenever zerolog fails to write an event on its output. If not set, an error is printed on the stderr. This handler must be thread safe and non-blocking.

--- a/globals.go
+++ b/globals.go
@@ -14,6 +14,10 @@ const (
 	// TimeFormatUnix defines a time format that makes time fields to be
 	// serialized as Unix timestamp integers in milliseconds.
 	TimeFormatUnixMs = "UNIXMS"
+
+	// timeFormatUnixMicro defines a time format that makes time fields to be
+	// serialized as Unix timestamp integers in microseconds.
+	timeFormatUnixMicro = "UNIXMICRO"
 )
 
 var (
@@ -57,7 +61,7 @@ var (
 	}
 
 	// TimeFieldFormat defines the time format of the Time field type. If set to
-	// TimeFormatUnix or TimeFormatUnixMs, the time is formatted as an UNIX
+	// TimeFormatUnix, TimeFormatUnixMs or timeFormatUnixMicro, the time is formatted as an UNIX
 	// timestamp as integer.
 	TimeFieldFormat = time.RFC3339
 

--- a/internal/json/time.go
+++ b/internal/json/time.go
@@ -9,6 +9,7 @@ const (
 	// Import from zerolog/global.go
 	timeFormatUnix   = ""
 	timeFormatUnixMs = "UNIXMS"
+	timeFormatUnixMicro = "UNIXMICRO"
 )
 
 // AppendTime formats the input time with the given format
@@ -19,6 +20,8 @@ func (e Encoder) AppendTime(dst []byte, t time.Time, format string) []byte {
 		return e.AppendInt64(dst, t.Unix())
 	case timeFormatUnixMs:
 		return e.AppendInt64(dst, t.UnixNano()/1000000)
+	case timeFormatUnixMicro:
+		return e.AppendInt64(dst, t.UnixNano()/1000)
 	}
 	return append(t.AppendFormat(append(dst, '"'), format), '"')
 }


### PR DESCRIPTION
This PR adds an additional case for supporting unix time format in microseconds.