### PR TITLE
modify Caller

### DIFF
--- a/event.go
+++ b/event.go
@@ -665,8 +665,14 @@ func (e *Event) Interface(key string, i interface{}) *Event {
 }
 
 // Caller adds the file:line of the caller with the zerolog.CallerFieldName key.
-func (e *Event) Caller() *Event {
-	return e.caller(CallerSkipFrameCount)
+func (e *Event) Caller(skip ...int) *Event {
+
+	sk := CallerSkipFrameCount
+	if len(skip) > 0 {
+		sk = skip[0] + CallerSkipFrameCount
+	}
+
+	return e.caller(sk)
 }
 
 func (e *Event) caller(skip int) *Event {

--- a/event.go
+++ b/event.go
@@ -668,12 +668,10 @@ func (e *Event) Interface(key string, i interface{}) *Event {
 // The argument skip is the number of stack frames to ascend
 // Skip If not passed, use the global variable CallerSkipFrameCount
 func (e *Event) Caller(skip ...int) *Event {
-
 	sk := CallerSkipFrameCount
 	if len(skip) > 0 {
 		sk = skip[0] + CallerSkipFrameCount
 	}
-
 	return e.caller(sk)
 }
 

--- a/event.go
+++ b/event.go
@@ -665,6 +665,8 @@ func (e *Event) Interface(key string, i interface{}) *Event {
 }
 
 // Caller adds the file:line of the caller with the zerolog.CallerFieldName key.
+// The argument skip is the number of stack frames to ascend
+// Skip If not passed, use the global variable CallerSkipFrameCount
 func (e *Event) Caller(skip ...int) *Event {
 
 	sk := CallerSkipFrameCount

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/zenazn/goji v0.9.0
 	golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,3 @@ require (
 	github.com/zenazn/goji v0.9.0
 	golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74
 )
-
-go 1.13


### PR DESCRIPTION
### Why write this pr
 To modify the Caller, you can pass a jump to a few function call stacks.
### demo
```go
    package main
    
    import (
        "github.com/rs/zerolog"
        "github.com/rs/zerolog/log"
    )
    
    func myError() {
        log.Debug().Caller(1).Str("test2", "v2").Send()
    }
    
    func foo() {
        log.Debug().Caller(2).Str("test2", "v2").Send()
    }
    
    func myError2() {
        foo()
    }
    func main() {
        zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
    
        log.Debug().Caller().Str("test1", "v1").Send()
        myError()
        myError2()
    }
```