### PR TITLE
Use ```bash instead of ```go

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Find out [who uses zerolog](https://github.com/rs/zerolog/wiki/Who-uses-zerolog)
 
 ## Installation
 
-```go
+```bash
 go get -u github.com/rs/zerolog/log
 ```
 


### PR DESCRIPTION
I just used ```` ```bash ```` instead of ```` ```go ```` in README.md because `go get -u github.com/rs/zerolog/log` is not golang. In this project, I found other command examples use ```` ```bash ````.