### PR TITLE
Add context hook support

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -42,6 +42,10 @@ func (l *Logger) WithContext(ctx context.Context) context.Context {
 // is associated, a disabled logger is returned.
 func Ctx(ctx context.Context) *Logger {
 	if l, ok := ctx.Value(ctxKey{}).(*Logger); ok {
+		for _, ctxHook := range l.ctxHooks {
+			l2 := ctxHook.Run(ctx, *l)
+			l = &l2
+		}
 		return l
 	}
 	return disabledLogger

--- a/ctx_hook.go
+++ b/ctx_hook.go
@@ -1,0 +1,17 @@
+package zerolog
+
+import "context"
+
+// Hook defines an interface to a contex hook.
+type CtxtHook interface {
+	// Run runs the hook with extracting of the Logger associated with the ctx.
+	Run(ctx context.Context, l Logger) Logger
+}
+
+// CtxtHookFunc is an adaptor to allow the use of an ordinary function as a Hook.
+type CtxtHookFunc func(ctx context.Context, l Logger) Logger
+
+// Run implements the CtxtHook interface.
+func (h CtxtHookFunc) Run(ctx context.Context, l Logger) Logger {
+	return h(ctx, l)
+}

--- a/log.go
+++ b/log.go
@@ -183,11 +183,12 @@ func ParseLevel(levelStr string) (Level, error) {
 // serialization to the Writer. If your Writer is not thread safe,
 // you may consider a sync wrapper.
 type Logger struct {
-	w       LevelWriter
-	level   Level
-	sampler Sampler
-	context []byte
-	hooks   []Hook
+	w        LevelWriter
+	level    Level
+	sampler  Sampler
+	context  []byte
+	hooks    []Hook
+	ctxHooks []CtxtHook
 }
 
 // New creates a root logger with given output writer. If the output writer implements
@@ -220,6 +221,9 @@ func (l Logger) Output(w io.Writer) Logger {
 	l2.sampler = l.sampler
 	if len(l.hooks) > 0 {
 		l2.hooks = append(l2.hooks, l.hooks...)
+	}
+	if len(l.ctxHooks) > 0 {
+		l2.ctxHooks = append(l2.ctxHooks, l.ctxHooks...)
 	}
 	if l.context != nil {
 		l2.context = make([]byte, len(l.context), cap(l.context))
@@ -272,6 +276,12 @@ func (l Logger) Sample(s Sampler) Logger {
 // Hook returns a logger with the h Hook.
 func (l Logger) Hook(h Hook) Logger {
 	l.hooks = append(l.hooks, h)
+	return l
+}
+
+// CtxHook returns a logger with the h CtxtHook.
+func (l Logger) CtxHook(h CtxtHook) Logger {
+	l.ctxHooks = append(l.ctxHooks, h)
 	return l
 }
 


### PR DESCRIPTION
I've got an idea to retranslate logger messages to Opentracing. It needs to add some mechanics to be able to propagate the span context from context.Context to the logger.