### PR TITLE
export buf

### DIFF
--- a/event.go
+++ b/event.go
@@ -79,6 +79,15 @@ func (e *Event) write() (err error) {
 	return
 }
 
+// Export buf member which casn be useful in some cases
+// while using hooks capability instead of using reflection
+func (e *Event) GetBuffer() []byte {
+	if e == nil {
+		return nil
+	}
+	return e.buf
+}
+
 // Enabled return false if the *Event is going to be filtered out by
 // log level or sampling.
 func (e *Event) Enabled() bool {


### PR DESCRIPTION
While using hook capability, in my use case, I had to access buf member in zerolog.Event struct, which is currently available only using reflection, which affects the performance.