### PR TITLE
Fix: Event.stack initialization error

### DIFF
--- a/event.go
+++ b/event.go
@@ -61,6 +61,7 @@ func newEvent(w LevelWriter, level Level) *Event {
 	e.buf = enc.AppendBeginMarker(e.buf)
 	e.w = w
 	e.level = level
+	e.stack = false
 	return e
 }
 


### PR DESCRIPTION
version: github.com/rs/zerolog/log  v1.18.0

When I test the following code

```go
package codes

import (
	"fmt"
	"testing"

	"github.com/pkg/errors"
	"github.com/rs/zerolog"
	"github.com/rs/zerolog/log"
	"github.com/rs/zerolog/pkgerrors"
)

func TestLog(t *testing.T) {

	f := func() error {
		return errors.WithStack(fmt.Errorf("abc"))
	}

	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack

	e := f()
	log.Error().Err(e).Int("id", 1).Send()
	log.Error().Stack().Err(e).Int("id", 2).Send()
	log.Error().Err(e).Int("id", 3).Send()
}
```

according to my understanding, err with `id = 2` will output stack information, while `id = 1` and `id = 3` will only output normal error information

but the output is not consistent with what I understand

```console
=== RUN   TestLog
{"level":"error","error":"abc","id":1,"time":"2020-03-30T23:52:12+08:00"}
{"level":"error","stack":[{"func":"TestLog.func1","line":"16","source":"code_log_test.go"},{"func":"TestLog","line":"21","source":"code_log_test.go"},{"func":"tRunner","line":"992","source":"testing.go"},{"func":"goexit","line":"1373","source":"asm_amd64.s"}],"error":"abc","id":2,"time":"2020-03-30T23:52:12+08:00"}
{"level":"error","stack":[{"func":"TestLog.func1","line":"16","source":"code_log_test.go"},{"func":"TestLog","line":"21","source":"code_log_test.go"},{"func":"tRunner","line":"992","source":"testing.go"},{"func":"goexit","line":"1373","source":"asm_amd64.s"}],"error":"abc","id":3,"time":"2020-03-30T23:52:12+08:00"}
--- PASS: TestLog (0.00s)
PASS
```

I found that the Event taken from the Pool did not initialize the stack, causing the stack to be reused

When I make the following changes, the result is correct

https://github.com/haozibi/zerolog/blob/6820ccdb22c5e934beb81a2c27e7778201d363cd/event.go#L56-L67

```console
=== RUN   TestLog
{"level":"error","error":"abc","id":1,"time":"2020-03-30T23:57:45+08:00"}
{"level":"error","stack":[{"func":"TestLog.func1","line":"16","source":"code_log_test.go"},{"func":"TestLog","line":"21","source":"code_log_test.go"},{"func":"tRunner","line":"992","source":"testing.go"},{"func":"goexit","line":"1373","source":"asm_amd64.s"}],"error":"abc","id":2,"time":"2020-03-30T23:57:45+08:00"}
{"level":"error","error":"abc","id":3,"time":"2020-03-30T23:57:45+08:00"}
--- PASS: TestLog (0.00s)
PASS
```

