### PR TITLE
fixes cbor unit test failures on 386 arch

### DIFF
--- a/internal/cbor/types_test.go
+++ b/internal/cbor/types_test.go
@@ -88,11 +88,8 @@ var integerTestCases = []struct {
 	{0xFFFF, "\x19\xff\xff"},
 	// Value in 4 bytes.
 	{0x10000, "\x1a\x00\x01\x00\x00"},
-	{0xFFFFFFFE, "\x1a\xff\xff\xff\xfe"},
+	{0x7FFFFFFE, "\x1a\x7f\xff\xff\xfe"},
 	{1000000, "\x1a\x00\x0f\x42\x40"},
-	// Value in 8 bytes.
-	{0xabcd100000000, "\x1b\x00\x0a\xbc\xd1\x00\x00\x00\x00"},
-	{1000000000000, "\x1b\x00\x00\x00\xe8\xd4\xa5\x10\x00"},
 	// Negative number test cases.
 	// Value included in the type.
 	{-1, "\x20"},
@@ -116,11 +113,9 @@ var integerTestCases = []struct {
 	{-1000, "\x39\x03\xe7"},
 	// Value in 4 bytes.
 	{-0x10001, "\x3a\x00\x01\x00\x00"},
-	{-0xFFFFFFFE, "\x3a\xff\xff\xff\xfd"},
+	{-0x7FFFFFFE, "\x3a\x7f\xff\xff\xfd"},
 	{-1000000, "\x3a\x00\x0f\x42\x3f"},
-	// Value in 8 bytes.
-	{-0xabcd100000001, "\x3b\x00\x0a\xbc\xd1\x00\x00\x00\x00"},
-	{-1000000000001, "\x3b\x00\x00\x00\xe8\xd4\xa5\x10\x00"},
+
 }
 
 func TestAppendInt(t *testing.T) {

--- a/internal/cbor/types_test_64.go
+++ b/internal/cbor/types_test_64.go
@@ -1,0 +1,35 @@
+// +build !386
+
+package cbor
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+var enc2 = Encoder{}
+
+var integerTestCases_64bit = []struct {
+	val    int
+	binary string
+}{
+	// Value in 8 bytes.
+	{0xabcd100000000, "\x1b\x00\x0a\xbc\xd1\x00\x00\x00\x00"},
+	{1000000000000, "\x1b\x00\x00\x00\xe8\xd4\xa5\x10\x00"},
+	// Value in 8 bytes.
+	{-0xabcd100000001, "\x3b\x00\x0a\xbc\xd1\x00\x00\x00\x00"},
+	{-1000000000001, "\x3b\x00\x00\x00\xe8\xd4\xa5\x10\x00"},
+
+}
+
+func TestAppendInt_64bit(t *testing.T) {
+	for _, tc := range integerTestCases_64bit {
+		s := enc2.AppendInt([]byte{}, tc.val)
+		got := string(s)
+		if got != tc.binary {
+			t.Errorf("AppendInt(0x%x)=0x%s, want: 0x%s",
+				tc.val, hex.EncodeToString(s),
+				hex.EncodeToString([]byte(tc.binary)))
+		}
+	}
+}


### PR DESCRIPTION
Moved 8btye integer tests to a different file
and that file has a build tag to be excluded from 386 arch

Fixed #163 

Signed-off-by: Ravi Raju <toravir@yahoo.com>