### PR TITLE
 Fix UpdateContext panic with empty Context

### DIFF
--- a/log.go
+++ b/log.go
@@ -252,6 +252,9 @@ func (l *Logger) UpdateContext(update func(c Context) Context) {
 	if cap(l.context) == 0 {
 		l.context = make([]byte, 0, 500)
 	}
+	if len(l.context) == 0 {
+		l.context = enc.AppendBeginMarker(l.context)
+	}
 	c := update(Context{*l})
 	l.context = c.l.context
 }

--- a/log_test.go
+++ b/log_test.go
@@ -772,3 +772,19 @@ func TestErrorHandler(t *testing.T) {
 		t.Errorf("ErrorHandler err = %#v, want %#v", got, want)
 	}
 }
+
+func TestUpdateEmptyContext(t *testing.T) {
+	var buf bytes.Buffer
+	log := New(&buf)
+
+	log.UpdateContext(func(c Context) Context {
+		return c.Str("foo", "bar")
+	})
+	log.Info().Msg("no panic")
+
+	want := `{"level":"info","foo":"bar","message":"no panic"}` + "\n"
+
+	if got := buf.String(); got != want {
+		t.Errorf("invalid log output:\ngot:  %q\nwant: %q", got, want)
+	}
+}


### PR DESCRIPTION
This fixes UpdateContext function when it is called with empty Context.

Fixes #239 