### PR TITLE
Add event level setter

### DIFF
--- a/event.go
+++ b/event.go
@@ -146,6 +146,12 @@ func (e *Event) msg(msg string) {
 	}
 }
 
+// Level sets the log event level.
+func (e *Event) Level(level Level) *Event {
+	e.level = level
+	return e
+}
+
 // Fields is a helper function to use a map to set fields using type assertion.
 func (e *Event) Fields(fields map[string]interface{}) *Event {
 	if e == nil {


### PR DESCRIPTION
Support #252 .

Zero-log's API first sets a level, which may not be the case in actual use. If you let go of this function, zero-log can support more, especially secondary packaging.