### PR TITLE
Fix: mutil.fancyWriter.ReadFrom records number of bytes written

### DIFF
--- a/hlog/internal/mutil/writer_proxy.go
+++ b/hlog/internal/mutil/writer_proxy.go
@@ -124,11 +124,16 @@ func (f *fancyWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 
 func (f *fancyWriter) ReadFrom(r io.Reader) (int64, error) {
 	if f.basicWriter.tee != nil {
-		return io.Copy(&f.basicWriter, r)
+		n, err := io.Copy(&f.basicWriter, r)
+		f.bytes += int(n)
+		return n, err
 	}
 	rf := f.basicWriter.ResponseWriter.(io.ReaderFrom)
 	f.basicWriter.maybeWriteHeader()
-	return rf.ReadFrom(r)
+
+	n, err := rf.ReadFrom(r)
+	f.bytes += int(n)
+	return n, err
 }
 
 type flushWriter struct {


### PR DESCRIPTION
Without this hlog.AccessHnalder reports a size written of 0 when the
ReadFrom method is used. This is easily visible when using
http.FileServer where all files are served with a logged size of 0.