### PR TITLE
Fix: AppendFloats64 first element treated as float32

### DIFF
--- a/internal/json/types.go
+++ b/internal/json/types.go
@@ -350,7 +350,7 @@ func (Encoder) AppendFloats64(dst []byte, vals []float64) []byte {
 		return append(dst, '[', ']')
 	}
 	dst = append(dst, '[')
-	dst = appendFloat(dst, vals[0], 32)
+	dst = appendFloat(dst, vals[0], 64)
 	if len(vals) > 1 {
 		for _, val := range vals[1:] {
 			dst = appendFloat(append(dst, ','), val, 64)


### PR DESCRIPTION
Hi!

Messing around with the API I found that in the `AppendFloats64` function the first element is treated like a float32 instead of a float64.