### PR TITLE
don't trim leading slash on callers outside cwd

### DIFF
--- a/console.go
+++ b/console.go
@@ -358,8 +358,8 @@ func consoleDefaultFormatCaller(noColor bool) Formatter {
 		if len(c) > 0 {
 			cwd, err := os.Getwd()
 			if err == nil {
-				c = strings.TrimPrefix(c, cwd)
-				c = strings.TrimPrefix(c, "/")
+				prefix := cwd + "/"
+				c = strings.TrimPrefix(c, prefix)
 			}
 			c = colorize(c, colorBold, noColor) + colorize(" >", colorCyan, noColor)
 		}


### PR DESCRIPTION
This PR fixes https://github.com/rs/zerolog/issues/265 by improving caller path trimming behavior.  Now a `/` is included in the prefix to be trimmed, rather than as a separate trim operation.  Thus if the prefix does not match, the leading slash is not trimmed.  