### PR TITLE
Log relative path for caller when using `ConsoleWriter`

### DIFF
--- a/console.go
+++ b/console.go
@@ -357,10 +357,8 @@ func consoleDefaultFormatCaller(noColor bool) Formatter {
 			c = cc
 		}
 		if len(c) > 0 {
-			cwd, err := os.Getwd()
-			if err == nil {
-				rel, err := filepath.Rel(cwd, c)
-				if err == nil {
+			if cwd, err := os.Getwd(); err == nil {
+				if rel, err := filepath.Rel(cwd, c); err == nil {
 					c = rel
 				}
 			}

--- a/console.go
+++ b/console.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -358,8 +359,10 @@ func consoleDefaultFormatCaller(noColor bool) Formatter {
 		if len(c) > 0 {
 			cwd, err := os.Getwd()
 			if err == nil {
-				prefix := cwd + "/"
-				c = strings.TrimPrefix(c, prefix)
+				rel, err := filepath.Rel(cwd, c)
+				if err == nil {
+					c = rel
+				}
 			}
 			c = colorize(c, colorBold, noColor) + colorize(" >", colorCyan, noColor)
 		}


### PR DESCRIPTION
This PR improves on #266 by always logging relative file path, rather than logging absolute path when the caller is outside the current directory.  This results in less verbose, yet equally useful, output.

With `master` after #266 merged:

```
8:29PM INF resource_project_test.go:114 > Cleaning up Rollbar projects from acceptance test runs.
8:29PM DBG /home/jmcvetta/projects/terraform-provider-rollbar/client/client.go:43 > Initializing Rollbar client
8:29PM DBG /home/jmcvetta/projects/terraform-provider-rollbar/client/project.go:112 > Successfully listed projects cleaned_projects=1 raw_projects=2351 url=https://api.rollbar.com/api/1/projects
8:29PM INF resource_project_test.go:138 > Projects cleanup complete
2020/11/02 20:29:58 [DEBUG] Running Sweeper (rollbar_team) in region (all)
8:29PM INF resource_team_test.go:160 > Cleaning up Rollbar teams from acceptance test runs.
8:29PM DBG /home/jmcvetta/projects/terraform-provider-rollbar/client/client.go:43 > Initializing Rollbar client
8:29PM INF /home/jmcvetta/projects/terraform-provider-rollbar/client/team.go:84 > Listing all teams
8:29PM DBG /home/jmcvetta/projects/terraform-provider-rollbar/client/team.go:102 > Successfully listed teams
8:29PM INF resource_team_test.go:184 > Teams cleanup complete
```

With this PR:

```
8:30PM INF resource_project_test.go:114 > Cleaning up Rollbar projects from acceptance test runs.
8:30PM DBG ../client/client.go:43 > Initializing Rollbar client
8:30PM DBG ../client/project.go:112 > Successfully listed projects cleaned_projects=1 raw_projects=2351 url=https://api.rollbar.com/api/1/projects
8:30PM INF resource_project_test.go:138 > Projects cleanup complete
2020/11/02 20:30:28 [DEBUG] Running Sweeper (rollbar_team) in region (all)
8:30PM INF resource_team_test.go:160 > Cleaning up Rollbar teams from acceptance test runs.
8:30PM DBG ../client/client.go:43 > Initializing Rollbar client
8:30PM INF ../client/team.go:84 > Listing all teams
8:30PM DBG ../client/team.go:102 > Successfully listed teams
8:30PM INF resource_team_test.go:184 > Teams cleanup complete
```

The relative paths are correctly interpreted and clickable in GoLand IDE:

![image](https://user-images.githubusercontent.com/55682/97873623-7b660100-1d4a-11eb-913a-f2d36ac33a17.png)
