### PR TITLE
Add Strs function to massive assignment string into array of log

### DIFF
--- a/array.go
+++ b/array.go
@@ -67,6 +67,14 @@ func (a *Array) Object(obj LogObjectMarshaler) *Array {
 	return a
 }
 
+// Strs append append the val as a string to the array with massive assignment
+func (a *Array) Strs(val ...string) *Array {
+	for _, v := range val {
+		a.Str(v)
+	}
+	return a
+}
+
 // Str append append the val as a string to the array.
 func (a *Array) Str(val string) *Array {
 	a.buf = enc.AppendString(enc.AppendArrayDelim(a.buf), val)

--- a/array_test.go
+++ b/array_test.go
@@ -27,8 +27,9 @@ func TestArray(t *testing.T) {
 		RawJSON([]byte(`{"some":"json"}`)).
 		Time(time.Time{}).
 		IPAddr(net.IP{192, 168, 0, 10}).
-		Dur(0)
-	want := `[true,1,2,3,4,5,6,7,8,9,10,11.98122,12.987654321,"a","b","1f",{"some":"json"},"0001-01-01T00:00:00Z","192.168.0.10",0]`
+		Dur(0).
+		Strs("you", "will", "like", "this")
+	want := `[true,1,2,3,4,5,6,7,8,9,10,11.98122,12.987654321,"a","b","1f",{"some":"json"},"0001-01-01T00:00:00Z","192.168.0.10",0,"you","will","like","this"]`
 	if got := decodeObjectToStr(a.write([]byte{})); got != want {
 		t.Errorf("Array.write()\ngot:  %s\nwant: %s", got, want)
 	}


### PR DESCRIPTION
**Problem**

There are repetitions when you want to do something like this:

```
zerolog.Arr().Str("some").Str("unecessary").Str("repetition")
```

**Proposal**

To simplify this assignment, I propose that we should have this kind of thing

```
zerolog.Arr().Strs("more", "efficient", "string", "assigment")
```

It would be a great coding experience if we could to this.

Tell me about your opinion @rs , should we do this also to other array assignment function? In this PR I just add `Strs` because that is the function that I really need to improve my coding experience :see_no_evil: 