### PR TITLE
Fix: Ensure event.Stack() is called before event.Err()

### DIFF
--- a/context.go
+++ b/context.go
@@ -406,17 +406,10 @@ func (c Context) CallerWithSkipFrameCount(skipFrameCount int) Context {
 	return c
 }
 
-type stackTraceHook struct{}
-
-func (sh stackTraceHook) Run(e *Event, level Level, msg string) {
-	e.Stack()
-}
-
-var sh = stackTraceHook{}
-
 // Stack enables stack trace printing for the error passed to Err().
 func (c Context) Stack() Context {
-	c.l = c.l.Hook(sh)
+	c.l.stack = true
+
 	return c
 }
 

--- a/log.go
+++ b/log.go
@@ -188,6 +188,7 @@ type Logger struct {
 	sampler Sampler
 	context []byte
 	hooks   []Hook
+	stack   bool
 }
 
 // New creates a root logger with given output writer. If the output writer implements
@@ -424,6 +425,9 @@ func (l *Logger) newEvent(level Level, done func(string)) *Event {
 	}
 	if l.context != nil && len(l.context) > 1 {
 		e.buf = enc.AppendObjectData(e.buf, l.context)
+	}
+	if l.stack {
+		e.Stack()
 	}
 	return e
 }


### PR DESCRIPTION
Based from prior work on #179 by @larsla.

The author of the original PR has not addressed the change requests and since I just ran into this bug I thought I would make the changes and open a new PR to resolve the issue.

This fixes an issue where `zerolog.New().With().Stack().Logger()` would not add a stack trace since the hooks are applied after `Err()` is called.