### PR TITLE
Initial Earthfile for running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Download released earthly
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: test zerolog with go ${{ matrix.go_version }}
-        run: earthly --build-arg GO_VERSION=${{ matrix.go_version }} --use-inline-cache +test
+        run: earthly --build-arg GO_VERSION=${{ matrix.go_version }} --ci +test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: GitHub Actions CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  tests:
+    name: +test +test-fail
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+    strategy:
+      matrix:
+        go_version: [
+            1.16,
+            1.15,
+            1.14,
+            1.13,
+            1.12,
+            ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: test zerolog with go ${{ matrix.go_version }}
+        run: earthly --build-arg GO_VERSION=${{ matrix.go_version }} --use-inline-cache +test

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,57 @@
+ARG GO_VERSION=1.16
+FROM golang:$GO_VERSION-buster
+
+deps:
+    RUN apt update && apt install -y systemd
+    RUN go get golang.org/x/tools/cmd/goimports
+    RUN go get golang.org/x/lint/golint
+    RUN go get github.com/gordonklaus/ineffassign
+
+code:
+    FROM +deps
+    WORKDIR /zerolog
+    COPY --dir cmd diode hlog internal journald log pkgerrors go.mod go.sum .
+    RUN go mod download
+    COPY *.go .
+
+lint:
+    FROM +code
+    RUN output="$(ineffassign ./... 2>&1 | grep -v '/earthly/ast/parser/.*\.go')" ; \
+        if [ -n "$output" ]; then \
+            echo "$output" ; \
+            exit 1 ; \
+        fi
+    RUN output="$(goimports -d $(find . -type f -name '*.go' | grep -v \.pb\.go) 2>&1)"  ; \
+        if [ -n "$output" ]; then \
+            echo "$output" ; \
+            exit 1 ; \
+        fi
+    RUN golint -set_exit_status ./...
+    RUN output="$(go vet ./... 2>&1)" ; \
+        if [ -n "$output" ]; then \
+            echo "$output" ; \
+            exit 1 ; \
+        fi
+
+test:
+    FROM +code
+    RUN /lib/systemd/systemd-journald & \
+        go test -race -cpu=1,2,4 -bench . -benchmem ./... && \
+        go test -tags binary_log -race -cpu=1,2,4 -bench . -benchmem ./...
+
+    # TODO expand on this test to validate the correct logs are received; currently
+    # there's a TODO for this under
+    # https://github.com/rs/zerolog/blob/master/journald/journald_test.go#L22-L50
+    RUN journalctl -o verbose | grep 'JSON={"level":"info","message":"Tick!"}'
+
+all:
+    # Currently the linter is failing, but you can enable it here:
+    #BUILD +lint
+
+    BUILD \
+        --build-arg GO_VERSION=1.16 \
+        --build-arg GO_VERSION=1.15 \
+        --build-arg GO_VERSION=1.14 \
+        --build-arg GO_VERSION=1.13 \
+        --build-arg GO_VERSION=1.12 \
+        +test


### PR DESCRIPTION
This PR is an example of how one can use [earthly](https://github.com/earthly/earthly) to perform integration tests both in github actions and locally.

# Running tests

## Requirements

### Docker

visit https://docs.docker.com/get-docker/ for installation instructions

### Earthly

Mac users can run:

    brew install earthly

and linux users can run:

    sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly && /usr/local/bin/earthly bootstrap'

For additional information visit https://earthly.dev/get-earthly or https://github.com/earthly/earthly

## Testing

To run the tests locally for go 1.16, in the root of the repo run:

    earthly +test

To specific a different version of go (e.g. 1.14), run:

    earthly --build-arg GO_VERSION=1.14 +test

To test against all versions between 1.12 and 1.16, run:

    earthly +all

Alternatively you can run these tests even without checking out the git repo via:

    earthly github.com/alexcb/zerolog+test

### Interactive testing
If you run into a command that fails, you can include the `--interactive` flag which will drop you into a shell within the container that's running the command that failed.

For instance, I added a linter which was showing there's some potential code syntax issues and is returning an error exit code, so you could run it via an interactive shell with:

    earthly --interactive github.com/alexcb/zerolog+lint


Signed-off-by: Alex Couture-Beil <alex@earthly.dev>