### PR TITLE
Added overlog to related project

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ with zerolog library is [CSD](https://github.com/toravir/csd/).
 ## Related Projects
 
 * [grpc-zerolog](https://github.com/cheapRoc/grpc-zerolog): Implementation of `grpclog.LoggerV2` interface using `zerolog`
+* [overlog](https://github.com/Trendyol/overlog): Implementation of `Mapped Diagnostic Context` interface using `zerolog`
 
 ## Benchmarks
 


### PR DESCRIPTION
I created a zerolog wrapper with mapped diagnostic context structure like Sl4j. When I saw related projects title, I thought it could be added. 

Best regards, thanks.