### PR TITLE
Fix Context.Stack()

### DIFF
--- a/context.go
+++ b/context.go
@@ -406,17 +406,9 @@ func (c Context) CallerWithSkipFrameCount(skipFrameCount int) Context {
 	return c
 }
 
-type stackTraceHook struct{}
-
-func (sh stackTraceHook) Run(e *Event, level Level, msg string) {
-	e.Stack()
-}
-
-var sh = stackTraceHook{}
-
 // Stack enables stack trace printing for the error passed to Err().
 func (c Context) Stack() Context {
-	c.l = c.l.Hook(sh)
+	c.l.stack = true
 	return c
 }
 

--- a/log.go
+++ b/log.go
@@ -188,6 +188,7 @@ type Logger struct {
 	sampler Sampler
 	context []byte
 	hooks   []Hook
+	stack   bool
 }
 
 // New creates a root logger with given output writer. If the output writer implements
@@ -424,6 +425,9 @@ func (l *Logger) newEvent(level Level, done func(string)) *Event {
 	}
 	if l.context != nil && len(l.context) > 1 {
 		e.buf = enc.AppendObjectData(e.buf, l.context)
+	}
+	if l.stack {
+		e.Stack()
 	}
 	return e
 }

--- a/pkgerrors/stacktrace_test.go
+++ b/pkgerrors/stacktrace_test.go
@@ -27,6 +27,22 @@ func TestLogStack(t *testing.T) {
 	}
 }
 
+func TestLogStackFromContext(t *testing.T) {
+	zerolog.ErrorStackMarshaler = MarshalStack
+
+	out := &bytes.Buffer{}
+	log := zerolog.New(out).With().Stack().Logger() // calling Stack() on log context instead of event
+
+	err := errors.Wrap(errors.New("error message"), "from error")
+	log.Log().Err(err).Msg("") // not explicitly calling Stack()
+
+	got := out.String()
+	want := `\{"stack":\[\{"func":"TestLogStackFromContext","line":"36","source":"stacktrace_test.go"\},.*\],"error":"from error: error message"\}\n`
+	if ok, _ := regexp.MatchString(want, got); !ok {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
 func BenchmarkLogStack(b *testing.B) {
 	zerolog.ErrorStackMarshaler = MarshalStack
 	out := &bytes.Buffer{}


### PR DESCRIPTION
As described in #129, the `Stack()` method on `Context` simply does not work right now, because the hook added by `Stack()` runs after `Err()` is called. Although @rs expressed some concerns about having a `Stack()` method on `Context` in the first place, the fact of the matter is that this method _does_ exist and doesn't work, so this is a bug that should be fixed.

This PR is basically the same as #130 and #179 but with conflicts fixed.

Closes #129, closes #130, closes #179.