### PR TITLE
Fix handling of printing caller with Write, Print, and Printf.

### DIFF
--- a/event.go
+++ b/event.go
@@ -20,12 +20,13 @@ var eventPool = &sync.Pool{
 // Event represents a log event. It is instanced by one of the level method of
 // Logger and finalized by the Msg or Msgf method.
 type Event struct {
-	buf   []byte
-	w     LevelWriter
-	level Level
-	done  func(msg string)
-	stack bool   // enable error stack trace
-	ch    []Hook // hooks from context
+	buf                  []byte
+	w                    LevelWriter
+	level                Level
+	done                 func(msg string)
+	stack                bool   // enable error stack trace
+	ch                   []Hook // hooks from context
+	callerSkipFrameCount int    // The number of additional frames to skip when printing the caller.
 }
 
 func putEvent(e *Event) {
@@ -62,6 +63,7 @@ func newEvent(w LevelWriter, level Level) *Event {
 	e.w = w
 	e.level = level
 	e.stack = false
+	e.callerSkipFrameCount = 0
 	return e
 }
 
@@ -685,6 +687,13 @@ func (e *Event) Interface(key string, i interface{}) *Event {
 	return e
 }
 
+// CallerSkipFrame instructs any future Caller calls to skip the specified number of frames.
+// This includes those added via hooks from the context.
+func (e *Event) CallerSkipFrame(skip int) *Event {
+	e.callerSkipFrameCount++
+	return e
+}
+
 // Caller adds the file:line of the caller with the zerolog.CallerFieldName key.
 // The argument skip is the number of stack frames to ascend
 // Skip If not passed, use the global variable CallerSkipFrameCount
@@ -700,7 +709,7 @@ func (e *Event) caller(skip int) *Event {
 	if e == nil {
 		return e
 	}
-	_, file, line, ok := runtime.Caller(skip)
+	_, file, line, ok := runtime.Caller(skip + e.callerSkipFrameCount)
 	if !ok {
 		return e
 	}

--- a/event.go
+++ b/event.go
@@ -690,7 +690,7 @@ func (e *Event) Interface(key string, i interface{}) *Event {
 // CallerSkipFrame instructs any future Caller calls to skip the specified number of frames.
 // This includes those added via hooks from the context.
 func (e *Event) CallerSkipFrame(skip int) *Event {
-	e.skipFrame++
+	e.skipFrame += skip
 	return e
 }
 

--- a/event.go
+++ b/event.go
@@ -20,13 +20,13 @@ var eventPool = &sync.Pool{
 // Event represents a log event. It is instanced by one of the level method of
 // Logger and finalized by the Msg or Msgf method.
 type Event struct {
-	buf                  []byte
-	w                    LevelWriter
-	level                Level
-	done                 func(msg string)
-	stack                bool   // enable error stack trace
-	ch                   []Hook // hooks from context
-	callerSkipFrameCount int    // The number of additional frames to skip when printing the caller.
+	buf       []byte
+	w         LevelWriter
+	level     Level
+	done      func(msg string)
+	stack     bool   // enable error stack trace
+	ch        []Hook // hooks from context
+	skipFrame int    // The number of additional frames to skip when printing the caller.
 }
 
 func putEvent(e *Event) {
@@ -63,7 +63,7 @@ func newEvent(w LevelWriter, level Level) *Event {
 	e.w = w
 	e.level = level
 	e.stack = false
-	e.callerSkipFrameCount = 0
+	e.skipFrame = 0
 	return e
 }
 
@@ -690,7 +690,7 @@ func (e *Event) Interface(key string, i interface{}) *Event {
 // CallerSkipFrame instructs any future Caller calls to skip the specified number of frames.
 // This includes those added via hooks from the context.
 func (e *Event) CallerSkipFrame(skip int) *Event {
-	e.callerSkipFrameCount++
+	e.skipFrame++
 	return e
 }
 
@@ -709,7 +709,7 @@ func (e *Event) caller(skip int) *Event {
 	if e == nil {
 		return e
 	}
-	_, file, line, ok := runtime.Caller(skip + e.callerSkipFrameCount)
+	_, file, line, ok := runtime.Caller(skip + e.skipFrame)
 	if !ok {
 		return e
 	}

--- a/log.go
+++ b/log.go
@@ -392,7 +392,7 @@ func (l *Logger) Log() *Event {
 // Arguments are handled in the manner of fmt.Print.
 func (l *Logger) Print(v ...interface{}) {
 	if e := l.Debug(); e.Enabled() {
-		e.CallerSkipFrame(1)
+		e.skipFrame++
 		e.Msg(fmt.Sprint(v...))
 	}
 }
@@ -401,7 +401,7 @@ func (l *Logger) Print(v ...interface{}) {
 // Arguments are handled in the manner of fmt.Printf.
 func (l *Logger) Printf(format string, v ...interface{}) {
 	if e := l.Debug(); e.Enabled() {
-		e.CallerSkipFrame(1)
+		e.skipFrame++
 		e.Msg(fmt.Sprintf(format, v...))
 	}
 }

--- a/log.go
+++ b/log.go
@@ -392,6 +392,7 @@ func (l *Logger) Log() *Event {
 // Arguments are handled in the manner of fmt.Print.
 func (l *Logger) Print(v ...interface{}) {
 	if e := l.Debug(); e.Enabled() {
+		e.CallerSkipFrame(1)
 		e.Msg(fmt.Sprint(v...))
 	}
 }
@@ -400,6 +401,7 @@ func (l *Logger) Print(v ...interface{}) {
 // Arguments are handled in the manner of fmt.Printf.
 func (l *Logger) Printf(format string, v ...interface{}) {
 	if e := l.Debug(); e.Enabled() {
+		e.CallerSkipFrame(1)
 		e.Msg(fmt.Sprintf(format, v...))
 	}
 }
@@ -412,6 +414,7 @@ func (l Logger) Write(p []byte) (n int, err error) {
 		// Trim CR added by stdlog.
 		p = p[0 : n-1]
 	}
+	e.CallerSkipFrame(1)
 	l.Log().Msg(string(p))
 	return
 }

--- a/log.go
+++ b/log.go
@@ -392,8 +392,7 @@ func (l *Logger) Log() *Event {
 // Arguments are handled in the manner of fmt.Print.
 func (l *Logger) Print(v ...interface{}) {
 	if e := l.Debug(); e.Enabled() {
-		e.skipFrame++
-		e.Msg(fmt.Sprint(v...))
+		e.CallerSkipFrame(1).Msg(fmt.Sprint(v...))
 	}
 }
 
@@ -401,8 +400,7 @@ func (l *Logger) Print(v ...interface{}) {
 // Arguments are handled in the manner of fmt.Printf.
 func (l *Logger) Printf(format string, v ...interface{}) {
 	if e := l.Debug(); e.Enabled() {
-		e.skipFrame++
-		e.Msg(fmt.Sprintf(format, v...))
+		e.CallerSkipFrame(1).Msg(fmt.Sprintf(format, v...))
 	}
 }
 

--- a/log.go
+++ b/log.go
@@ -414,8 +414,7 @@ func (l Logger) Write(p []byte) (n int, err error) {
 		// Trim CR added by stdlog.
 		p = p[0 : n-1]
 	}
-	e.CallerSkipFrame(1)
-	l.Log().Msg(string(p))
+	l.Log().CallerSkipFrame(1).Msg(string(p))
 	return
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -3,6 +3,7 @@ package log
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 
@@ -114,13 +115,13 @@ func Log() *zerolog.Event {
 // Print sends a log event using debug level and no extra field.
 // Arguments are handled in the manner of fmt.Print.
 func Print(v ...interface{}) {
-	Logger.Print(v...)
+	Logger.Debug().CallerSkipFrame(1).Msg(fmt.Sprint(v...))
 }
 
 // Printf sends a log event using debug level and no extra field.
 // Arguments are handled in the manner of fmt.Printf.
 func Printf(format string, v ...interface{}) {
-	Logger.Printf(format, v...)
+	Logger.Debug().CallerSkipFrame(1).Msgf(format, v...)
 }
 
 // Ctx returns the Logger associated with the ctx. If no logger


### PR DESCRIPTION
This fixes https://github.com/rs/zerolog/issues/243, as well as the identical issue around Print and Printf calls in both zerolog and zerolog/log.

With these changes, we now get correct caller data in all those cases.