### PR TITLE
Fix copying stack setting in logger's Output method

### DIFF
--- a/log.go
+++ b/log.go
@@ -223,6 +223,7 @@ func (l Logger) Output(w io.Writer) Logger {
 	l2 := New(w)
 	l2.level = l.level
 	l2.sampler = l.sampler
+	l2.stack = l.stack
 	if len(l.hooks) > 0 {
 		l2.hooks = append(l2.hooks, l.hooks...)
 	}


### PR DESCRIPTION
Minimum example to reproduce the problem:
```go
package main

import (
	"os"

	"github.com/pkg/errors"
	"github.com/rs/zerolog"
	"github.com/rs/zerolog/log"
	"github.com/rs/zerolog/pkgerrors"
)

func main() {
	log.Logger = log.With().Caller().Stack().Logger().Output(zerolog.ConsoleWriter{Out: os.Stderr})
	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack

	log.Info().Err(errors.New("test")).Send()
}
```
Without my changes `stack` isn't printed.