### PR TITLE
Panic of Event.Object() and Event.EmbedObject() with nil

### DIFF
--- a/event.go
+++ b/event.go
@@ -207,6 +207,12 @@ func (e *Event) Object(key string, obj LogObjectMarshaler) *Event {
 		return e
 	}
 	e.buf = enc.AppendKey(e.buf, key)
+	if obj == nil {
+		e.buf = enc.AppendNil(e.buf)
+
+		return e
+	}
+
 	e.appendObject(obj)
 	return e
 }
@@ -222,6 +228,9 @@ func (e *Event) Func(f func(e *Event)) *Event {
 // EmbedObject marshals an object that implement the LogObjectMarshaler interface.
 func (e *Event) EmbedObject(obj LogObjectMarshaler) *Event {
 	if e == nil {
+		return e
+	}
+	if obj == nil {
 		return e
 	}
 	obj.MarshalZerologObject(e)

--- a/event_test.go
+++ b/event_test.go
@@ -37,3 +37,29 @@ func TestEvent_AnErr(t *testing.T) {
 		})
 	}
 }
+
+func TestEvent_ObjectWithNil(t *testing.T) {
+	var buf bytes.Buffer
+	e := newEvent(levelWriterAdapter{&buf}, DebugLevel)
+	_ = e.Object("obj", nil)
+	_ = e.write()
+
+	want := `{"obj":null}`
+	got := strings.TrimSpace(buf.String())
+	if got != want {
+		t.Errorf("Event.Object() = %q, want %q", got, want)
+	}
+}
+
+func TestEvent_EmbedObjectWithNil(t *testing.T) {
+	var buf bytes.Buffer
+	e := newEvent(levelWriterAdapter{&buf}, DebugLevel)
+	_ = e.EmbedObject(nil)
+	_ = e.write()
+
+	want := "{}"
+	got := strings.TrimSpace(buf.String())
+	if got != want {
+		t.Errorf("Event.EmbedObject() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
This patch supports `Event.Object` and `Event.EmbedObject` can get nil without panic.