### PR TITLE
Allow user configuration of default logger to return from Ctx()

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -39,9 +39,12 @@ func (l *Logger) WithContext(ctx context.Context) context.Context {
 }
 
 // Ctx returns the Logger associated with the ctx. If no logger
-// is associated, a disabled logger is returned.
+// is associated, DefaultContextLogger is returned, unless DefaultContextLogger
+// is nil, in which case a disabled logger is returned.
 func Ctx(ctx context.Context) *Logger {
 	if l, ok := ctx.Value(ctxKey{}).(*Logger); ok {
+		return l
+	} else if l = DefaultContextLogger; l != nil {
 		return l
 	}
 	return disabledLogger

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -27,6 +27,13 @@ func TestCtx(t *testing.T) {
 	if log2 != disabledLogger {
 		t.Error("Ctx did not return the expected logger")
 	}
+
+	DefaultContextLogger = &log
+	t.Cleanup(func() { DefaultContextLogger = nil })
+	log2 = Ctx(context.Background())
+	if log2 != &log {
+		t.Error("Ctx did not return the expected logger")
+	}
 }
 
 func TestCtxDisabled(t *testing.T) {

--- a/globals.go
+++ b/globals.go
@@ -100,6 +100,10 @@ var (
 	// output. If not set, an error is printed on the stderr. This handler must
 	// be thread safe and non-blocking.
 	ErrorHandler func(err error)
+
+	// DefaultContextLogger is returned from Ctx() if there is no logger associated
+	// with the context.
+	DefaultContextLogger *Logger
 )
 
 var (


### PR DESCRIPTION
If a user is trying to fetch a logger from their context, they probably want to log something.
A likely use case is the desire to fetch the logger from the context, but fall back to using the global logger if none is associated.  This could facilitate migrating code towards using context-based loggers incrementally.

In order to keep backward compatibility with existing users of the library, we can add a configuration setting, which if left unchanged, causes the backwards compatible behavior.  I chose to follow the existing pattern of configuration via global variables.

I hope that by making the configuration var a `*Logger` we offer maximum flexibility to users who want this feature, while keeping the existing behaviors for users who don't.   Added a unit test to cover the new case.