### PR TITLE
allow RemoteAddrHandler to include addresses which have no port

### DIFF
--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -3,7 +3,6 @@ package hlog
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"time"
 
@@ -79,16 +78,10 @@ func RequestHandler(fieldKey string) func(next http.Handler) http.Handler {
 func RemoteAddrHandler(fieldKey string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			addr := r.RemoteAddr
-
-			if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
-				addr = host
-			}
-
-			if addr != "" {
+			if r.RemoteAddr != "" {
 				log := zerolog.Ctx(r.Context())
 				log.UpdateContext(func(c zerolog.Context) zerolog.Context {
-					return c.Str(fieldKey, addr)
+					return c.Str(fieldKey, r.RemoteAddr)
 				})
 			}
 			next.ServeHTTP(w, r)

--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -79,10 +79,16 @@ func RequestHandler(fieldKey string) func(next http.Handler) http.Handler {
 func RemoteAddrHandler(fieldKey string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			addr := r.RemoteAddr
+
 			if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+				addr = host
+			}
+
+			if addr != "" {
 				log := zerolog.Ctx(r.Context())
 				log.UpdateContext(func(c zerolog.Context) zerolog.Context {
-					return c.Str(fieldKey, host)
+					return c.Str(fieldKey, addr)
 				})
 			}
 			next.ServeHTTP(w, r)

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -100,7 +100,7 @@ func TestRemoteAddrHandler(t *testing.T) {
 	}))
 	h = NewHandler(zerolog.New(out))(h)
 	h.ServeHTTP(nil, r)
-	if want, got := `{"ip":"1.2.3.4"}`+"\n", decodeIfBinary(out); want != got {
+	if want, got := `{"ip":"1.2.3.4:1234"}`+"\n", decodeIfBinary(out); want != got {
 		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
 	}
 }
@@ -116,7 +116,7 @@ func TestRemoteAddrHandlerIPv6(t *testing.T) {
 	}))
 	h = NewHandler(zerolog.New(out))(h)
 	h.ServeHTTP(nil, r)
-	if want, got := `{"ip":"2001:db8:a0b:12f0::1"}`+"\n", decodeIfBinary(out); want != got {
+	if want, got := `{"ip":"[2001:db8:a0b:12f0::1]:1234"}`+"\n", decodeIfBinary(out); want != got {
 		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
 	}
 }

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -121,6 +121,38 @@ func TestRemoteAddrHandlerIPv6(t *testing.T) {
 	}
 }
 
+func TestRemoteAddrHandlerNoPort(t *testing.T) {
+	out := &bytes.Buffer{}
+	r := &http.Request{
+		RemoteAddr: "1.2.3.4",
+	}
+	h := RemoteAddrHandler("ip")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l := FromRequest(r)
+		l.Log().Msg("")
+	}))
+	h = NewHandler(zerolog.New(out))(h)
+	h.ServeHTTP(nil, r)
+	if want, got := `{"ip":"1.2.3.4"}`+"\n", decodeIfBinary(out); want != got {
+		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
+	}
+}
+
+func TestRemoteAddrHandlerIPv6NoPort(t *testing.T) {
+	out := &bytes.Buffer{}
+	r := &http.Request{
+		RemoteAddr: "2001:db8:a0b:12f0::1",
+	}
+	h := RemoteAddrHandler("ip")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l := FromRequest(r)
+		l.Log().Msg("")
+	}))
+	h = NewHandler(zerolog.New(out))(h)
+	h.ServeHTTP(nil, r)
+	if want, got := `{"ip":"2001:db8:a0b:12f0::1"}`+"\n", decodeIfBinary(out); want != got {
+		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
+	}
+}
+
 func TestUserAgentHandler(t *testing.T) {
 	out := &bytes.Buffer{}
 	r := &http.Request{

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -121,38 +121,6 @@ func TestRemoteAddrHandlerIPv6(t *testing.T) {
 	}
 }
 
-func TestRemoteAddrHandlerNoPort(t *testing.T) {
-	out := &bytes.Buffer{}
-	r := &http.Request{
-		RemoteAddr: "1.2.3.4",
-	}
-	h := RemoteAddrHandler("ip")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		l := FromRequest(r)
-		l.Log().Msg("")
-	}))
-	h = NewHandler(zerolog.New(out))(h)
-	h.ServeHTTP(nil, r)
-	if want, got := `{"ip":"1.2.3.4"}`+"\n", decodeIfBinary(out); want != got {
-		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
-	}
-}
-
-func TestRemoteAddrHandlerIPv6NoPort(t *testing.T) {
-	out := &bytes.Buffer{}
-	r := &http.Request{
-		RemoteAddr: "2001:db8:a0b:12f0::1",
-	}
-	h := RemoteAddrHandler("ip")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		l := FromRequest(r)
-		l.Log().Msg("")
-	}))
-	h = NewHandler(zerolog.New(out))(h)
-	h.ServeHTTP(nil, r)
-	if want, got := `{"ip":"2001:db8:a0b:12f0::1"}`+"\n", decodeIfBinary(out); want != got {
-		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
-	}
-}
-
 func TestUserAgentHandler(t *testing.T) {
 	out := &bytes.Buffer{}
 	r := &http.Request{


### PR DESCRIPTION
Many HTTP servers end up being placed behind reverse proxies. As a result, many devs use middleware to map reverse-proxy headers to the request RemoteAddr. Many of these headers don't include ports, causing an otherwise valid RemoteAddrHandler to not set the field.﻿
