### PR TITLE
Fields helper accepts both map and slice

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -148,16 +148,16 @@ func BenchmarkLogFieldType(b *testing.B) {
 		{"a", "a", 0},
 	}
 	objects := []obj{
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
 	}
 	errs := []error{errors.New("a"), errors.New("b"), errors.New("c"), errors.New("d"), errors.New("e")}
 	types := map[string]func(e *Event) *Event{
@@ -272,16 +272,16 @@ func BenchmarkContextFieldType(b *testing.B) {
 		{"a", "a", 0},
 	}
 	objects := []obj{
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
-		obj{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
+		{"a", "a", 0},
 	}
 	errs := []error{errors.New("a"), errors.New("b"), errors.New("c"), errors.New("d"), errors.New("e")}
 	types := map[string]func(c Context) Context{

--- a/binary_test.go
+++ b/binary_test.go
@@ -364,6 +364,42 @@ func ExampleEvent_Durs() {
 	// Output: {"foo":"bar","durs":[10000,20000],"message":"hello world"}
 }
 
+func ExampleEvent_Fields_map() {
+	fields := map[string]interface{}{
+		"bar": "baz",
+		"n":   1,
+	}
+
+	dst := bytes.Buffer{}
+	log := New(&dst)
+
+	log.Log().
+		Str("foo", "bar").
+		Fields(fields).
+		Msg("hello world")
+
+	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
+	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+}
+
+func ExampleEvent_Fields_slice() {
+	fields := []interface{}{
+		"bar", "baz",
+		"n", 1,
+	}
+
+	dst := bytes.Buffer{}
+	log := New(&dst)
+
+	log.Log().
+		Str("foo", "bar").
+		Fields(fields).
+		Msg("hello world")
+
+	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
+	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+}
+
 func ExampleContext_Dict() {
 	dst := bytes.Buffer{}
 	log := New(&dst).With().
@@ -509,4 +545,40 @@ func ExampleContext_Durs() {
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","durs":[10000,20000],"message":"hello world"}
+}
+
+func ExampleContext_Fields_map() {
+	fields := map[string]interface{}{
+		"bar": "baz",
+		"n":   1,
+	}
+
+	dst := bytes.Buffer{}
+	log := New(&dst).With().
+		Str("foo", "bar").
+		Fields(fields).
+		Logger()
+
+	log.Log().Msg("hello world")
+
+	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
+	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+}
+
+func ExampleContext_Fields_slice() {
+	fields := []interface{}{
+		"bar", "baz",
+		"n", 1,
+	}
+
+	dst := bytes.Buffer{}
+	log := New(&dst).With().
+		Str("foo", "bar").
+		Fields(fields).
+		Logger()
+
+	log.Log().Msg("hello world")
+
+	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
+	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
 }

--- a/context.go
+++ b/context.go
@@ -24,6 +24,16 @@ func (c Context) Fields(fields map[string]interface{}) Context {
 	return c
 }
 
+// KeyValues is a helper function to use a slice to set fields using type assertion.
+// The key/value pairs must alternate string keys and arbitrary values.
+func (c Context) KeyValues(keyValues []interface{}) Context {
+	if kvLen := len(keyValues); kvLen&0x1 == 1 { // odd number
+		keyValues = keyValues[:kvLen-1]
+	}
+	c.l.context = appendKeyValues(c.l.context, keyValues)
+	return c
+}
+
 // Dict adds the field key with the dict to the logger context.
 func (c Context) Dict(key string, dict *Event) Context {
 	dict.buf = enc.AppendEndMarker(dict.buf)

--- a/context.go
+++ b/context.go
@@ -18,19 +18,11 @@ func (c Context) Logger() Logger {
 	return c.l
 }
 
-// Fields is a helper function to use a map to set fields using type assertion.
-func (c Context) Fields(fields map[string]interface{}) Context {
+// Fields is a helper function to use a map or slice to set fields using type assertion.
+// Only map[string]interface{} and []interface{} are accepted. []interface{} must
+// alternate string keys and arbitrary values, and extraneous ones are ignored.
+func (c Context) Fields(fields interface{}) Context {
 	c.l.context = appendFields(c.l.context, fields)
-	return c
-}
-
-// KeyValues is a helper function to use a slice to set fields using type assertion.
-// The key/value pairs must alternate string keys and arbitrary values.
-func (c Context) KeyValues(keyValues []interface{}) Context {
-	if kvLen := len(keyValues); kvLen&0x1 == 1 { // odd number
-		keyValues = keyValues[:kvLen-1]
-	}
-	c.l.context = appendKeyValues(c.l.context, keyValues)
 	return c
 }
 

--- a/event.go
+++ b/event.go
@@ -157,6 +157,19 @@ func (e *Event) Fields(fields map[string]interface{}) *Event {
 	return e
 }
 
+// KeyValues is a helper function to use a slice to set fields using type assertion.
+// The key/value pairs must alternate string keys and arbitrary values.
+func (e *Event) KeyValues(keyValues []interface{}) *Event {
+	if e == nil {
+		return e
+	}
+	if kvLen := len(keyValues); kvLen&0x1 == 1 { // odd number
+		keyValues = keyValues[:kvLen-1]
+	}
+	e.buf = appendKeyValues(e.buf, keyValues)
+	return e
+}
+
 // Dict adds the field key with a dict to the event context.
 // Use zerolog.Dict() to create the dictionary.
 func (e *Event) Dict(key string, dict *Event) *Event {

--- a/event.go
+++ b/event.go
@@ -148,25 +148,14 @@ func (e *Event) msg(msg string) {
 	}
 }
 
-// Fields is a helper function to use a map to set fields using type assertion.
-func (e *Event) Fields(fields map[string]interface{}) *Event {
+// Fields is a helper function to use a map or slice to set fields using type assertion.
+// Only map[string]interface{} and []interface{} are accepted. []interface{} must
+// alternate string keys and arbitrary values, and extraneous ones are ignored.
+func (e *Event) Fields(fields interface{}) *Event {
 	if e == nil {
 		return e
 	}
 	e.buf = appendFields(e.buf, fields)
-	return e
-}
-
-// KeyValues is a helper function to use a slice to set fields using type assertion.
-// The key/value pairs must alternate string keys and arbitrary values.
-func (e *Event) KeyValues(keyValues []interface{}) *Event {
-	if e == nil {
-		return e
-	}
-	if kvLen := len(keyValues); kvLen&0x1 == 1 { // odd number
-		keyValues = keyValues[:kvLen-1]
-	}
-	e.buf = appendKeyValues(e.buf, keyValues)
 	return e
 }
 

--- a/fields.go
+++ b/fields.go
@@ -18,9 +18,23 @@ func appendFields(dst []byte, fields map[string]interface{}) []byte {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	keyValues := make([]interface{}, 2)
 	for _, key := range keys {
+		keyValues[0] = key
+		keyValues[1] = fields[key]
+		dst = appendKeyValues(dst, keyValues)
+	}
+	return dst
+}
+
+func appendKeyValues(dst []byte, keyValues []interface{}) []byte {
+	for i, kvLen := 0, len(keyValues); i < kvLen; i += 2 {
+		k, val := keyValues[i], keyValues[i+1]
+		key, ok := k.(string)
+		if !ok {
+			continue
+		}
 		dst = enc.AppendKey(dst, key)
-		val := fields[key]
 		if val, ok := val.(LogObjectMarshaler); ok {
 			e := newEvent(nil, 0)
 			e.buf = e.buf[:0]

--- a/fields.go
+++ b/fields.go
@@ -12,29 +12,36 @@ func isNilValue(i interface{}) bool {
 	return (*[2]uintptr)(unsafe.Pointer(&i))[1] == 0
 }
 
-func appendFields(dst []byte, fields map[string]interface{}) []byte {
-	keys := make([]string, 0, len(fields))
-	for key := range fields {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	keyValues := make([]interface{}, 2)
-	for _, key := range keys {
-		keyValues[0] = key
-		keyValues[1] = fields[key]
-		dst = appendKeyValues(dst, keyValues)
+func appendFields(dst []byte, fields interface{}) []byte {
+	switch fields := fields.(type) {
+	case []interface{}:
+		if n := len(fields); n&0x1 == 1 { // odd number
+			fields = fields[:n-1]
+		}
+		dst = appendFieldList(dst, fields)
+	case map[string]interface{}:
+		keys := make([]string, 0, len(fields))
+		for key := range fields {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		kv := make([]interface{}, 2)
+		for _, key := range keys {
+			kv[0], kv[1] = key, fields[key]
+			dst = appendFieldList(dst, kv)
+		}
 	}
 	return dst
 }
 
-func appendKeyValues(dst []byte, keyValues []interface{}) []byte {
-	for i, kvLen := 0, len(keyValues); i < kvLen; i += 2 {
-		k, val := keyValues[i], keyValues[i+1]
-		key, ok := k.(string)
-		if !ok {
+func appendFieldList(dst []byte, kvList []interface{}) []byte {
+	for i, n := 0, len(kvList); i < n; i += 2 {
+		key, val := kvList[i], kvList[i+1]
+		if key, ok := key.(string); ok {
+			dst = enc.AppendKey(dst, key)
+		} else {
 			continue
 		}
-		dst = enc.AppendKey(dst, key)
 		if val, ok := val.(LogObjectMarshaler); ok {
 			e := newEvent(nil, 0)
 			e.buf = e.buf[:0]

--- a/log_example_test.go
+++ b/log_example_test.go
@@ -335,6 +335,38 @@ func ExampleEvent_Durs() {
 	// Output: {"foo":"bar","durs":[10000,20000],"message":"hello world"}
 }
 
+func ExampleEvent_Fields_map() {
+	fields := map[string]interface{}{
+		"bar": "baz",
+		"n":   1,
+	}
+
+	log := zerolog.New(os.Stdout)
+
+	log.Log().
+		Str("foo", "bar").
+		Fields(fields).
+		Msg("hello world")
+
+	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+}
+
+func ExampleEvent_Fields_slice() {
+	fields := []interface{}{
+		"bar", "baz",
+		"n", 1,
+	}
+
+	log := zerolog.New(os.Stdout)
+
+	log.Log().
+		Str("foo", "bar").
+		Fields(fields).
+		Msg("hello world")
+
+	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+}
+
 func ExampleContext_Dict() {
 	log := zerolog.New(os.Stdout).With().
 		Str("foo", "bar").
@@ -483,4 +515,36 @@ func ExampleContext_MacAddr() {
 	log.Log().Msg("hello world")
 
 	// Output: {"hostMAC":"00:14:22:01:23:45","message":"hello world"}
+}
+
+func ExampleContext_Fields_map() {
+	fields := map[string]interface{}{
+		"bar": "baz",
+		"n":   1,
+	}
+
+	log := zerolog.New(os.Stdout).With().
+		Str("foo", "bar").
+		Fields(fields).
+		Logger()
+
+	log.Log().Msg("hello world")
+
+	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+}
+
+func ExampleContext_Fields_slice() {
+	fields := []interface{}{
+		"bar", "baz",
+		"n", 1,
+	}
+
+	log := zerolog.New(os.Stdout).With().
+		Str("foo", "bar").
+		Fields(fields).
+		Logger()
+
+	log.Log().Msg("hello world")
+
+	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
 }


### PR DESCRIPTION
Useful for logging wrappers like [zerologr ](https://github.com/hn8/zerologr) to reuse the same code for Fields helper (which requires map). No extra allocation for variadic arguments or slice of key/value pairs. It avoids stack copy overhead from variadic arguments (as in Zap ...Fields)