### PR TITLE
feat: implement an optional ErrorWriter interface

### DIFF
--- a/array.go
+++ b/array.go
@@ -17,7 +17,8 @@ var arrayPool = &sync.Pool{
 // Array is used to prepopulate an array of items
 // which can be re-used to add to log messages.
 type Array struct {
-	buf []byte
+	buf  []byte
+	errs []error
 }
 
 func putArray(a *Array) {
@@ -38,6 +39,7 @@ func putArray(a *Array) {
 func Arr() *Array {
 	a := arrayPool.Get().(*Array)
 	a.buf = a.buf[:0]
+	a.errs = a.errs[:0]
 	return a
 }
 
@@ -93,6 +95,10 @@ func (a *Array) RawJSON(val []byte) *Array {
 
 // Err serializes and appends the err to the array.
 func (a *Array) Err(err error) *Array {
+	if err != nil {
+		a.errs = append(a.errs, err)
+	}
+
 	switch m := ErrorMarshalFunc(err).(type) {
 	case LogObjectMarshaler:
 		e := newEvent(nil, 0)

--- a/log.go
+++ b/log.go
@@ -201,6 +201,7 @@ type Logger struct {
 	context []byte
 	hooks   []Hook
 	stack   bool
+	errs    []error
 }
 
 // New creates a root logger with given output writer. If the output writer implements
@@ -238,6 +239,9 @@ func (l Logger) Output(w io.Writer) Logger {
 	if l.context != nil {
 		l2.context = make([]byte, len(l.context), cap(l.context))
 		copy(l2.context, l.context)
+	}
+	if len(l.errs) > 0 {
+		l2.errs = append(l2.errs, l.errs...)
 	}
 	return l2
 }
@@ -441,6 +445,9 @@ func (l *Logger) newEvent(level Level, done func(string)) *Event {
 	}
 	if l.stack {
 		e.Stack()
+	}
+	if l.errs != nil {
+		e.errs = append(e.errs, l.errs...)
 	}
 	return e
 }

--- a/writer.go
+++ b/writer.go
@@ -12,6 +12,14 @@ type LevelWriter interface {
 	WriteLevel(level Level, p []byte) (n int, err error)
 }
 
+// ErrorWriter defines an optional interface: If it's satisfied, any
+// errors stored within the event will be passed along in a call to
+// WriteErrors() in order to facilitate e.g. persistence via an
+// external error tracker.
+type ErrorWriter interface {
+	WriteErrors(level Level, errs []error)
+}
+
 type levelWriterAdapter struct {
 	io.Writer
 }


### PR DESCRIPTION
@rs no idea if you'll want to merge this - this is something I'll be adopting internally so that errors logged via zerolog at warn level or above can be enriched with request context, then pushed into an external error aggregator; Sentry in my case.

This builds on the idea proposed in https://github.com/rs/zerolog/issues/329

A few design notes:
- The reason I went for an optional interface on the writer is because
  errors need level context, generally. In my use case, I don't want to
  send errors below "warn" level to an external error aggregator.
- Intended use of this requires an ErrorWriter implementation, which
  should be injected into the logger on a per-request basis such that
  all logged errors are enriched with the same request context.
- The []error embedded within the Logger, Event, and Array structs is
  there to guarantee Discard() behaves correctly, and also that e.g. an
  Array that is built up can benefit from the ErrorWriter that may be
  embedded within the event it will eventually be attached to.