### PR TITLE
New TestWriter for logging to testing.TB

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -107,6 +107,7 @@ func MultiLevelWriter(writers ...io.Writer) LevelWriter {
 type TestingLog interface {
 	Log(args ...interface{})
 	Logf(format string, args ...interface{})
+	Helper()
 }
 
 // TestWriter is a writer that writes to testing.TB.
@@ -119,11 +120,13 @@ type TestWriter struct {
 
 // NewTestWriter creates a writer that logs to the testing.TB.
 func NewTestWriter(t TestingLog) TestWriter {
-	return TestWriter{T: t, Frame: 1}
+	return TestWriter{T: t}
 }
 
 // Write to testing.TB.
 func (t TestWriter) Write(p []byte) (n int, err error) {
+	t.T.Helper()
+
 	n = len(p)
 
 	// Strip trailing newline because t.Log always adds one.
@@ -131,8 +134,8 @@ func (t TestWriter) Write(p []byte) (n int, err error) {
 
 	// Try to correct the log file and line number to the caller.
 	if t.Frame > 0 {
-		_, origFile, origLine, _ := runtime.Caller(0)
-		_, frameFile, frameLine, ok := runtime.Caller(t.Frame)
+		_, origFile, origLine, _ := runtime.Caller(1)
+		_, frameFile, frameLine, ok := runtime.Caller(1 + t.Frame)
 		if ok {
 			erase := strings.Repeat("\b", len(path.Base(origFile))+len(strconv.Itoa(origLine))+3)
 			t.T.Logf("%s%s:%d: %s", erase, path.Base(frameFile), frameLine, p)
@@ -147,6 +150,6 @@ func (t TestWriter) Write(p []byte) (n int, err error) {
 // ConsoleTestWriter creates an option that correctly sets the file frame depth for testing.TB log.
 func ConsoleTestWriter(t testing.TB) func(w *ConsoleWriter) {
 	return func(w *ConsoleWriter) {
-		w.Out = TestWriter{T: t, Frame: 7}
+		w.Out = TestWriter{T: t, Frame: 6}
 	}
 }

--- a/writer.go
+++ b/writer.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"testing"
 )
 
 // LevelWriter defines as interface a writer may implement in order
@@ -148,7 +147,7 @@ func (t TestWriter) Write(p []byte) (n int, err error) {
 }
 
 // ConsoleTestWriter creates an option that correctly sets the file frame depth for testing.TB log.
-func ConsoleTestWriter(t testing.TB) func(w *ConsoleWriter) {
+func ConsoleTestWriter(t TestingLog) func(w *ConsoleWriter) {
 	return func(w *ConsoleWriter) {
 		w.Out = TestWriter{T: t, Frame: 6}
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -114,18 +114,18 @@ func TestResilientMultiWriter(t *testing.T) {
 	}
 }
 
-type tb struct {
+type testingLog struct {
 	testing.TB
 	buf bytes.Buffer
 }
 
-func (t *tb) Log(args ...interface{}) {
-	if _, err := t.buf.WriteString(fmt.Sprintln(args...)); err != nil {
+func (t *testingLog) Log(args ...interface{}) {
+	if _, err := t.buf.WriteString(fmt.Sprint(args...)); err != nil {
 		t.Error(err)
 	}
 }
 
-func (t *tb) Logf(format string, args ...interface{}) {
+func (t *testingLog) Logf(format string, args ...interface{}) {
 	if _, err := t.buf.WriteString(fmt.Sprintf(format, args...)); err != nil {
 		t.Error(err)
 	}
@@ -152,8 +152,8 @@ func TestTestWriter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tb := &tb{TB: t} // Capture TB log buffer.
-			w := TestWriter{TB: tb}
+			tb := &testingLog{TB: t} // Capture TB log buffer.
+			w := TestWriter{T: tb}
 
 			n, err := w.Write(tt.write)
 			if err != nil {

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,10 +1,12 @@
-// +build !binary_log
-// +build !windows
+//go:build !binary_log && !windows
+// +build !binary_log,!windows
 
 package zerolog
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -53,45 +55,45 @@ func TestResilientMultiWriter(t *testing.T) {
 		writers []io.Writer
 	}{
 		{
-			name:    "All valid writers",
+			name: "All valid writers",
 			writers: []io.Writer{
-				mockedWriter {
+				mockedWriter{
 					wantErr: false,
 				},
-				mockedWriter {
-					wantErr: false,
-				},
-			},
-		},
-		{
-			name:    "All invalid writers",
-			writers: []io.Writer{
-				mockedWriter {
-					wantErr: true,
-				},
-				mockedWriter {
-					wantErr: true,
-				},
-			},
-		},
-		{
-			name:    "First invalid writer",
-			writers: []io.Writer{
-				mockedWriter {
-					wantErr: true,
-				},
-				mockedWriter {
+				mockedWriter{
 					wantErr: false,
 				},
 			},
 		},
 		{
-			name:    "First valid writer",
+			name: "All invalid writers",
 			writers: []io.Writer{
-				mockedWriter {
+				mockedWriter{
+					wantErr: true,
+				},
+				mockedWriter{
+					wantErr: true,
+				},
+			},
+		},
+		{
+			name: "First invalid writer",
+			writers: []io.Writer{
+				mockedWriter{
+					wantErr: true,
+				},
+				mockedWriter{
 					wantErr: false,
 				},
-				mockedWriter {
+			},
+		},
+		{
+			name: "First valid writer",
+			writers: []io.Writer{
+				mockedWriter{
+					wantErr: false,
+				},
+				mockedWriter{
 					wantErr: true,
 				},
 			},
@@ -110,4 +112,66 @@ func TestResilientMultiWriter(t *testing.T) {
 		}
 		writeCalls = 0
 	}
+}
+
+type tb struct {
+	testing.TB
+	buf bytes.Buffer
+}
+
+func (t *tb) Log(args ...interface{}) {
+	if _, err := t.buf.WriteString(fmt.Sprintln(args...)); err != nil {
+		t.Error(err)
+	}
+}
+
+func (t *tb) Logf(format string, args ...interface{}) {
+	if _, err := t.buf.WriteString(fmt.Sprintf(format, args...)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTestWriter(t *testing.T) {
+	tests := []struct {
+		name  string
+		write []byte
+		want  []byte
+	}{{
+		name:  "newline",
+		write: []byte("newline\n"),
+		want:  []byte("newline"),
+	}, {
+		name:  "oneline",
+		write: []byte("oneline"),
+		want:  []byte("oneline"),
+	}, {
+		name:  "twoline",
+		write: []byte("twoline\n\n"),
+		want:  []byte("twoline"),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tb := &tb{TB: t} // Capture TB log buffer.
+			w := TestWriter{TB: tb}
+
+			n, err := w.Write(tt.write)
+			if err != nil {
+				t.Error(err)
+			}
+			if n != len(tt.write) {
+				t.Errorf("Expected %d write length but got %d", len(tt.write), n)
+			}
+			p := tb.buf.Bytes()
+			if !bytes.Equal(tt.want, p) {
+				t.Errorf("Expected %q, got %q.", tt.want, p)
+			}
+
+			log := New(NewConsoleWriter(ConsoleTestWriter(t)))
+			log.Info().Str("name", tt.name).Msg("Success!")
+
+			tb.buf.Reset()
+		})
+	}
+
 }


### PR DESCRIPTION
Implements a writer to wrap testing.TB for help in testing, https://github.com/rs/zerolog/issues/368.

The go testing log injects the callers filename and line number, which is incorrect for deeply nested functions. To get around this we allow to specify the frame depth and rewrite it. Not necessary but makes it pretty. Added an option for the ConsoleWriter to set the correct frame (although it's brittle to rewrites, not sure how to test better). 