### PR TITLE
ConsoleWriter: remove fields written within "PartsOrder" so they are not duplicated in output log

### DIFF
--- a/console.go
+++ b/console.go
@@ -109,6 +109,7 @@ func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 
 	for _, p := range w.PartsOrder {
 		w.writePart(buf, evt, p)
+		delete(evt, p)
 	}
 
 	w.writeFields(evt, buf)


### PR DESCRIPTION
close #204 

once the field is written into Parts, remove it form `evt` so it's no longer written to fields