### PR TITLE
Call exit/panic in Fatal/Panic log events even if the logging is disabled for this event

### DIFF
--- a/log.go
+++ b/log.go
@@ -428,6 +428,9 @@ func (l Logger) Write(p []byte) (n int, err error) {
 func (l *Logger) newEvent(level Level, done func(string)) *Event {
 	enabled := l.should(level)
 	if !enabled {
+		if done != nil {
+			done("")
+		}
 		return nil
 	}
 	e := newEvent(l.w, level)


### PR DESCRIPTION
Issue #392 
