### PR TITLE
journald: don't call Enabled before each write

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/rs/zerolog
 go 1.15
 
 require (
-	github.com/coreos/go-systemd/v22 v22.3.2
+	github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534
 	github.com/mattn/go-colorable v0.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/rs/xid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534 h1:rtAn27wIbmOGUs7RIbVgPEjb31ehTVniDwPGXyMxm5U=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=


### PR DESCRIPTION
Enabled opens and close a socket connection by reusing or initializing
a global connection. It does not try to recreate the global socket connection if it failed.
It is useless to call Enabled each time.

I also updated go-systemd to the current development release to include
the following fix:

https://github.com/coreos/go-systemd/commit/75f33b08dbe229fb37b96bf0076907b6b8159af1

This is the only journal related change since the latest stable release.

In SFTPGo I can log to journal conditionally, with the current go-systemd version a socket is always opened even if the journal logging feature is not used, this is the reason I propose to use the latest development version while waiting for a new upstream release