### PR TITLE
ctx: Modify WithContext to use a non-pointer receiver

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -25,9 +25,9 @@ type ctxKey struct{}
 //     l.UpdateContext(func(c Context) Context {
 //         return c.Str("bar", "baz")
 //     })
-func (l *Logger) WithContext(ctx context.Context) context.Context {
+func (l Logger) WithContext(ctx context.Context) context.Context {
 	if lp, ok := ctx.Value(ctxKey{}).(*Logger); ok {
-		if lp == l {
+		if lp == &l {
 			// Do not store same logger.
 			return ctx
 		}
@@ -35,7 +35,7 @@ func (l *Logger) WithContext(ctx context.Context) context.Context {
 		// Do not store disabled logger.
 		return ctx
 	}
-	return context.WithValue(ctx, ctxKey{}, l)
+	return context.WithValue(ctx, ctxKey{}, &l)
 }
 
 // Ctx returns the Logger associated with the ctx. If no logger

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -45,7 +45,7 @@ func TestCtxDisabled(t *testing.T) {
 
 	l := New(ioutil.Discard).With().Str("foo", "bar").Logger()
 	ctx = l.WithContext(ctx)
-	if Ctx(ctx) != &l {
+	if !reflect.DeepEqual(Ctx(ctx), &l) {
 		t.Error("WithContext did not store logger")
 	}
 
@@ -53,18 +53,18 @@ func TestCtxDisabled(t *testing.T) {
 		return c.Str("bar", "baz")
 	})
 	ctx = l.WithContext(ctx)
-	if Ctx(ctx) != &l {
+	if !reflect.DeepEqual(Ctx(ctx), &l) {
 		t.Error("WithContext did not store updated logger")
 	}
 
 	l = l.Level(DebugLevel)
 	ctx = l.WithContext(ctx)
-	if Ctx(ctx) != &l {
+	if !reflect.DeepEqual(Ctx(ctx), &l) {
 		t.Error("WithContext did not store copied logger")
 	}
 
 	ctx = dl.WithContext(ctx)
-	if Ctx(ctx) != &dl {
+	if !reflect.DeepEqual(Ctx(ctx), &dl) {
 		t.Error("WithContext did not override logger with a disabled logger")
 	}
 }


### PR DESCRIPTION
This PR addresses the issues discussed in #116 and #400.

I have modified the receiver for `WithContext` to use a non-pointer receiver and fixed the tests.

The alternative to this, as discussed, would be to modify `Logger()` to return a pointer. If this is the preferred fix, I'd be happy to implement. However, it will have more knock-on effects.

Fixes #116.