### PR TITLE
Use everywhere InterfaceMarshalFunc

### DIFF
--- a/console.go
+++ b/console.go
@@ -206,7 +206,7 @@ func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer
 		case json.Number:
 			buf.WriteString(fv(fValue))
 		default:
-			b, err := json.Marshal(fValue)
+			b, err := InterfaceMarshalFunc(fValue)
 			if err != nil {
 				fmt.Fprintf(buf, colorize("[error: %v]", colorRed, w.NoColor), err)
 			} else {

--- a/journald/journald.go
+++ b/journald/journald.go
@@ -102,7 +102,7 @@ func (w journalWriter) Write(p []byte) (n int, err error) {
 		case json.Number:
 			args[jKey] = fmt.Sprint(value)
 		default:
-			b, err := json.Marshal(value)
+			b, err := zerolog.InterfaceMarshalFunc(value)
 			if err != nil {
 				args[jKey] = fmt.Sprintf("[error: %v]", err)
 			} else {


### PR DESCRIPTION
So that one can configure it everywhere. My use case: I want to JSON marshal without HTML escaping, so that it is easier to read `<` and `>` in the console.