### PR TITLE
feat: add hlog CustomFieldHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ In this example we use [alice](https://github.com/justinas/alice) to install log
 log := zerolog.New(os.Stdout).With().
     Timestamp().
     Str("role", "my-service").
-    Str("host", host).
+    Str("host", "local-hostname").
     Logger()
 
 c := alice.New()
@@ -544,6 +544,7 @@ c = c.Append(hlog.RemoteAddrHandler("ip"))
 c = c.Append(hlog.UserAgentHandler("user_agent"))
 c = c.Append(hlog.RefererHandler("referer"))
 c = c.Append(hlog.RequestIDHandler("req_id", "Request-Id"))
+c = c.Append(hlog.CustomFieldHandler("custom_field", "abc"))
 
 // Here is your final handler
 h := c.Then(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -555,7 +556,7 @@ h := c.Then(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
         Str("status", "ok").
         Msg("Something happened")
 
-    // Output: {"level":"info","time":"2001-02-03T04:05:06Z","role":"my-service","host":"local-hostname","req_id":"b4g0l5t6tfid6dtrapu0","user":"current user","status":"ok","message":"Something happened"}
+    // Output: {"level":"info","time":"2001-02-03T04:05:06Z","role":"my-service","host":"local-hostname","req_id":"b4g0l5t6tfid6dtrapu0","custom_field":"abc","user":"current user","status":"ok","message":"Something happened"}
 }))
 http.Handle("/", h)
 
@@ -567,6 +568,7 @@ if err := http.ListenAndServe(":8080", nil); err != nil {
 ## Multiple Log Output
 `zerolog.MultiLevelWriter` may be used to send the log message to multiple outputs. 
 In this example, we send the log message to both `os.Stdout` and the in-built ConsoleWriter.
+
 ```go
 func main() {
 	consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}

--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -175,6 +175,21 @@ func RequestIDHandler(fieldKey, headerName string) func(next http.Handler) http.
 	}
 }
 
+// CustomFieldHandler adds given key and value to the context's logger.
+func CustomFieldHandler(fieldKey, val string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if fieldKey != "" {
+				log := zerolog.Ctx(r.Context())
+				log.UpdateContext(func(c zerolog.Context) zerolog.Context {
+					return c.Str(fieldKey, val)
+				})
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // CustomHeaderHandler adds given header from request's header as a field to
 // the context's logger using fieldKey as field key.
 func CustomHeaderHandler(fieldKey, header string) func(next http.Handler) http.Handler {

--- a/hlog/hlog_example_test.go
+++ b/hlog/hlog_example_test.go
@@ -54,6 +54,7 @@ func Example_handler() {
 	c = c.Append(hlog.UserAgentHandler("user_agent"))
 	c = c.Append(hlog.RefererHandler("referer"))
 	//c = c.Append(hlog.RequestIDHandler("req_id", "Request-Id"))
+	c = c.Append(hlog.CustomFieldHandler("custom_field", "abc"))
 
 	// Here is your final handler
 	h := c.Then(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -69,5 +70,5 @@ func Example_handler() {
 
 	h.ServeHTTP(httptest.NewRecorder(), &http.Request{})
 
-	// Output: {"level":"info","role":"my-service","host":"local-hostname","user":"current user","status":"ok","time":"2001-02-03T04:05:06Z","message":"Something happened"}
+	// Output: {"level":"info","role":"my-service","host":"local-hostname","custom_field":"abc","user":"current user","status":"ok","time":"2001-02-03T04:05:06Z","message":"Something happened"}
 }

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -182,6 +182,20 @@ func TestRequestIDHandler(t *testing.T) {
 	h.ServeHTTP(httptest.NewRecorder(), r)
 }
 
+func TestCustomFieldHandler(t *testing.T) {
+	out := &bytes.Buffer{}
+	r := &http.Request{}
+	h := CustomFieldHandler("testField", "testValue")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l := FromRequest(r)
+		l.Log().Msg("")
+	}))
+	h = NewHandler(zerolog.New(out))(h)
+	h.ServeHTTP(nil, r)
+	if want, got := `{"testField":"testValue"}`+"\n", decodeIfBinary(out); want != got {
+		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
+	}
+}
+
 func TestCustomHeaderHandler(t *testing.T) {
 	out := &bytes.Buffer{}
 	r := &http.Request{


### PR DESCRIPTION
hlog has plenty of useful handlers. What's currently missing is an easy way to enrich log context with a custom field and value, which come from an external source (not from a request itself).

The PR adds a `CustomFieldHandler`. Please, feel free to suggest a better name if needed.