### PR TITLE
Adding Event.Type(...) method to log the type of an object

### DIFF
--- a/event.go
+++ b/event.go
@@ -719,6 +719,15 @@ func (e *Event) Interface(key string, i interface{}) *Event {
 	return e
 }
 
+// Type adds the field key with val's type using reflection.
+func (e *Event) Type(key string, val interface{}) *Event {
+	if e == nil {
+		return e
+	}
+	e.buf = enc.AppendType(enc.AppendKey(e.buf, key), val)
+	return e
+}
+
 // CallerSkipFrame instructs any future Caller calls to skip the specified number of frames.
 // This includes those added via hooks from the context.
 func (e *Event) CallerSkipFrame(skip int) *Event {

--- a/internal/json/types.go
+++ b/internal/json/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"reflect"
 	"strconv"
 )
 
@@ -371,7 +372,10 @@ func (e Encoder) AppendInterface(dst []byte, i interface{}) []byte {
 
 // AppendType appends the parameter type (as a string) to the input byte slice.
 func (e Encoder) AppendType(dst []byte, i interface{}) []byte {
-	return e.AppendString(dst, fmt.Sprintf("%T", i))
+	if i == nil {
+		return e.AppendString(dst, "<nil>")
+	}
+	return e.AppendString(dst, reflect.TypeOf(i).String())
 }
 
 // AppendObjectData takes in an object that is already in a byte array

--- a/internal/json/types.go
+++ b/internal/json/types.go
@@ -369,6 +369,11 @@ func (e Encoder) AppendInterface(dst []byte, i interface{}) []byte {
 	return append(dst, marshaled...)
 }
 
+// AppendType appends the parameter type (as a string) to the input byte slice.
+func (e Encoder) AppendType(dst []byte, i interface{}) []byte {
+	return e.AppendString(dst, fmt.Sprintf("%T", i))
+}
+
 // AppendObjectData takes in an object that is already in a byte array
 // and adds it to the dst.
 func (Encoder) AppendObjectData(dst []byte, o []byte) []byte {

--- a/internal/json/types_test.go
+++ b/internal/json/types_test.go
@@ -166,6 +166,27 @@ func Test_appendMac(t *testing.T) {
 	}
 }
 
+func Test_appendType(t *testing.T) {
+	typeTests := []struct {
+		input interface{}
+		want  []byte
+	}{
+		{42, []byte(`"int"`)},
+		{net.HardwareAddr{0x12, 0x34, 0x00, 0x00, 0x90, 0xab}, []byte(`"net.HardwareAddr"`)},
+		{float64(2.50), []byte(`"float64"`)},
+		{nil, []byte(`"<nil>"`)},
+		{true, []byte(`"bool"`)},
+	}
+
+	for _, tt := range typeTests {
+		t.Run("MAC", func(t *testing.T) {
+			if got := enc.AppendType([]byte{}, tt.input); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("appendType() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_appendObjectData(t *testing.T) {
 	tests := []struct {
 		dst  []byte

--- a/internal/json/types_test.go
+++ b/internal/json/types_test.go
@@ -168,18 +168,19 @@ func Test_appendMac(t *testing.T) {
 
 func Test_appendType(t *testing.T) {
 	typeTests := []struct {
+		label string
 		input interface{}
 		want  []byte
 	}{
-		{42, []byte(`"int"`)},
-		{net.HardwareAddr{0x12, 0x34, 0x00, 0x00, 0x90, 0xab}, []byte(`"net.HardwareAddr"`)},
-		{float64(2.50), []byte(`"float64"`)},
-		{nil, []byte(`"<nil>"`)},
-		{true, []byte(`"bool"`)},
+		{"int", 42, []byte(`"int"`)},
+		{"MAC", net.HardwareAddr{0x12, 0x34, 0x00, 0x00, 0x90, 0xab}, []byte(`"net.HardwareAddr"`)},
+		{"float64", float64(2.50), []byte(`"float64"`)},
+		{"nil", nil, []byte(`"<nil>"`)},
+		{"bool", true, []byte(`"bool"`)},
 	}
 
 	for _, tt := range typeTests {
-		t.Run("MAC", func(t *testing.T) {
+		t.Run(tt.label, func(t *testing.T) {
 			if got := enc.AppendType([]byte{}, tt.input); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("appendType() = %s, want %s", got, tt.want)
 			}


### PR DESCRIPTION
I found myself wanting to log the type of an object and was convinced there would be a method to do that already, but I didn't find one.  Here's a case where one might want such a method:

```go
	var value interface{}
	var result string
	switch v := value.(type) {
	case int:
		result = strconv.Itoa(v)
	case string:
		result = v
	default:
		log.Panic().Type("type", v).Msg("Unexpected value type")
	}
	log.Info().Msg(result)
```

Let me know if there's anything else that needs to change for this to get accepted.