### PR TITLE
Implement encoding.TextUnmarshaler and encoding.TextMarshaler for Level

### DIFF
--- a/log.go
+++ b/log.go
@@ -195,37 +195,9 @@ func (l *Level) UnmarshalText(text []byte) error {
 	if l == nil {
 		return errors.New("can't unmarshal a nil *Level")
 	}
-	*l = NoLevel
-	switch string(text) {
-	case LevelFieldMarshalFunc(TraceLevel):
-		*l = TraceLevel
-	case LevelFieldMarshalFunc(DebugLevel):
-		*l = DebugLevel
-	case LevelFieldMarshalFunc(InfoLevel):
-		*l = InfoLevel
-	case LevelFieldMarshalFunc(WarnLevel):
-		*l = WarnLevel
-	case LevelFieldMarshalFunc(ErrorLevel):
-		*l = ErrorLevel
-	case LevelFieldMarshalFunc(FatalLevel):
-		*l = FatalLevel
-	case LevelFieldMarshalFunc(PanicLevel):
-		*l = PanicLevel
-	case LevelFieldMarshalFunc(Disabled):
-		*l = Disabled
-	case LevelFieldMarshalFunc(NoLevel):
-		*l = NoLevel
-	default:
-		i, err := strconv.Atoi(string(text))
-		if err != nil {
-			return fmt.Errorf("Unknown Level String: '%s', defaulting to NoLevel", string(text))
-		}
-		if i > 127 || i < -128 {
-			return fmt.Errorf("Out-Of-Bounds Level: '%d', defaulting to NoLevel", i)
-		}
-		*l = Level(i)
-	}
-	return nil
+	var err error
+	*l, err = ParseLevel(string(text))
+	return err
 }
 
 // MarshalText implements encoding.TextMarshaler to allow for easy writing into toml/yaml/json formats

--- a/log_test.go
+++ b/log_test.go
@@ -999,11 +999,11 @@ func TestUnmarshalTextLevel(t *testing.T) {
 			var l Level
 			err := l.UnmarshalText([]byte(tt.args.levelStr))
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseLevel() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("UnmarshalText() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if l != tt.want {
-				t.Errorf("ParseLevel() got = %v, want %v", l, tt.want)
+				t.Errorf("UnmarshalText() got = %v, want %v", l, tt.want)
 			}
 		})
 	}

--- a/log_test.go
+++ b/log_test.go
@@ -907,6 +907,33 @@ func TestLevel_String(t *testing.T) {
 	}
 }
 
+func TestLevel_MarshalText(t *testing.T) {
+	tests := []struct {
+		name string
+		l    Level
+		want string
+	}{
+		{"trace", TraceLevel, "trace"},
+		{"debug", DebugLevel, "debug"},
+		{"info", InfoLevel, "info"},
+		{"warn", WarnLevel, "warn"},
+		{"error", ErrorLevel, "error"},
+		{"fatal", FatalLevel, "fatal"},
+		{"panic", PanicLevel, "panic"},
+		{"disabled", Disabled, "disabled"},
+		{"nolevel", NoLevel, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := tt.l.MarshalText(); err != nil {
+				t.Errorf("MarshalText couldn't marshal: %v", tt.l)
+			} else if string(got) != tt.want {
+				t.Errorf("String() = %v, want %v", string(got), tt.want)
+			}
+		})
+	}
+}
+
 func TestParseLevel(t *testing.T) {
 	type args struct {
 		levelStr string
@@ -939,6 +966,44 @@ func TestParseLevel(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("ParseLevel() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnmarshalTextLevel(t *testing.T) {
+	type args struct {
+		levelStr string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Level
+		wantErr bool
+	}{
+		{"trace", args{"trace"}, TraceLevel, false},
+		{"debug", args{"debug"}, DebugLevel, false},
+		{"info", args{"info"}, InfoLevel, false},
+		{"warn", args{"warn"}, WarnLevel, false},
+		{"error", args{"error"}, ErrorLevel, false},
+		{"fatal", args{"fatal"}, FatalLevel, false},
+		{"panic", args{"panic"}, PanicLevel, false},
+		{"disabled", args{"disabled"}, Disabled, false},
+		{"nolevel", args{""}, NoLevel, false},
+		{"-1", args{"-1"}, TraceLevel, false},
+		{"-2", args{"-2"}, Level(-2), false},
+		{"-3", args{"-3"}, Level(-3), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var l Level
+			err := l.UnmarshalText([]byte(tt.args.levelStr))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseLevel() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if l != tt.want {
+				t.Errorf("ParseLevel() got = %v, want %v", l, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Similar to #13, distinct from #48 and #57 since they don't solve the problem of automatically parsing level when reading a yaml/toml/json file.