### PR TITLE
Field LogLevel at Logger, Context & Event Levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ Some settings can be changed and will be applied to all loggers:
 * `RawJSON`: Adds a field with an already encoded JSON (`[]byte`)
 * `Hex`: Adds a field with value formatted as a hexadecimal string (`[]byte`)
 * `Interface`: Uses reflection to marshal the type.
+* `LogLevel`: Explicitly adds/replaces log level field.
 
 Most fields are also available in the slice format (`Strs` for `[]string`, `Errs` for `[]error` etc.)
 

--- a/binary_test.go
+++ b/binary_test.go
@@ -1,3 +1,4 @@
+//go:build binary_log
 // +build binary_log
 
 package zerolog
@@ -6,8 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-
-	//	"io/ioutil"
 	stdlog "log"
 	"time"
 )
@@ -16,9 +15,9 @@ func ExampleBinaryNew() {
 	dst := bytes.Buffer{}
 	log := New(&dst)
 
-	log.Info().Msg("hello world")
+	log.Info().LogLevel().Msg("hello world")
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
-	// Output: {"level":"info","message":"hello world"}
+	// Output: {"level":"info","level":"info","message":"hello world"}
 }
 
 func ExampleLogger_With() {
@@ -28,7 +27,7 @@ func ExampleLogger_With() {
 		Str("foo", "bar").
 		Logger()
 
-	log.Info().Msg("hello world")
+	log.Info().LogLevel().Msg("hello world")
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 
 	// Output: {"level":"info","foo":"bar","message":"hello world"}
@@ -38,8 +37,8 @@ func ExampleLogger_Level() {
 	dst := bytes.Buffer{}
 	log := New(&dst).Level(WarnLevel)
 
-	log.Info().Msg("filtered out message")
-	log.Error().Msg("kept message")
+	log.Info().LogLevel().Msg("filtered out message")
+	log.Error().LogLevel().Msg("kept message")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"level":"error","message":"kept message"}
@@ -49,10 +48,10 @@ func ExampleLogger_Sample() {
 	dst := bytes.Buffer{}
 	log := New(&dst).Sample(&BasicSampler{N: 2})
 
-	log.Info().Msg("message 1")
-	log.Info().Msg("message 2")
-	log.Info().Msg("message 3")
-	log.Info().Msg("message 4")
+	log.Info().LogLevel().Msg("message 1")
+	log.Info().LogLevel().Msg("message 2")
+	log.Info().LogLevel().Msg("message 3")
+	log.Info().LogLevel().Msg("message 4")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"level":"info","message":"message 1"}
@@ -82,7 +81,7 @@ func ExampleLogger_Hook() {
 	dst := bytes.Buffer{}
 	log := New(&dst).Hook(levelNameHook).Hook(messageHook)
 
-	log.Info().Msg("hello world")
+	log.Info().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"level":"info","level_name":"info","the_message":"hello world","message":"hello world"}
@@ -90,7 +89,7 @@ func ExampleLogger_Hook() {
 
 func ExampleLogger_Print() {
 	dst := bytes.Buffer{}
-	log := New(&dst)
+	log := New(&dst).LogLevel()
 
 	log.Print("hello world")
 
@@ -100,7 +99,7 @@ func ExampleLogger_Print() {
 
 func ExampleLogger_Printf() {
 	dst := bytes.Buffer{}
-	log := New(&dst)
+	log := New(&dst).LogLevel()
 
 	log.Printf("hello %s", "world")
 
@@ -115,6 +114,7 @@ func ExampleLogger_Trace() {
 	log.Trace().
 		Str("foo", "bar").
 		Int("n", 123).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -128,6 +128,7 @@ func ExampleLogger_Debug() {
 	log.Debug().
 		Str("foo", "bar").
 		Int("n", 123).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -141,6 +142,7 @@ func ExampleLogger_Info() {
 	log.Info().
 		Str("foo", "bar").
 		Int("n", 123).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -153,6 +155,7 @@ func ExampleLogger_Warn() {
 
 	log.Warn().
 		Str("foo", "bar").
+		LogLevel().
 		Msg("a warning message")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -165,6 +168,7 @@ func ExampleLogger_Error() {
 
 	log.Error().
 		Err(errors.New("some error")).
+		LogLevel().
 		Msg("error doing something")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -176,6 +180,7 @@ func ExampleLogger_WithLevel() {
 	log := New(&dst)
 
 	log.WithLevel(InfoLevel).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -186,6 +191,7 @@ func ExampleLogger_Write() {
 	dst := bytes.Buffer{}
 	log := New(&dst).With().
 		Str("foo", "bar").
+		LogLevel().
 		Logger()
 
 	stdlog.SetFlags(0)
@@ -204,6 +210,7 @@ func ExampleLogger_Log() {
 	log.Log().
 		Str("foo", "bar").
 		Str("bar", "baz").
+		LogLevel().
 		Msg("")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -220,6 +227,7 @@ func ExampleEvent_Dict() {
 			Str("bar", "baz").
 			Int("n", 1),
 		).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -256,6 +264,7 @@ func ExampleEvent_Array() {
 			Str("baz").
 			Int(1),
 		).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -275,6 +284,7 @@ func ExampleEvent_Array_object() {
 	log.Log().
 		Str("foo", "bar").
 		Array("users", u).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -291,6 +301,7 @@ func ExampleEvent_Object() {
 	log.Log().
 		Str("foo", "bar").
 		Object("user", u).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -306,6 +317,7 @@ func ExampleEvent_EmbedObject() {
 	log.Log().
 		Str("foo", "bar").
 		EmbedObject(price).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -325,6 +337,7 @@ func ExampleEvent_Interface() {
 	log.Log().
 		Str("foo", "bar").
 		Interface("obj", obj).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -340,6 +353,7 @@ func ExampleEvent_Dur() {
 	log.Log().
 		Str("foo", "bar").
 		Dur("dur", d).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -358,6 +372,7 @@ func ExampleEvent_Durs() {
 	log.Log().
 		Str("foo", "bar").
 		Durs("durs", d).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -376,6 +391,7 @@ func ExampleEvent_Fields_map() {
 	log.Log().
 		Str("foo", "bar").
 		Fields(fields).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -394,6 +410,7 @@ func ExampleEvent_Fields_slice() {
 	log.Log().
 		Str("foo", "bar").
 		Fields(fields).
+		LogLevel().
 		Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
@@ -409,7 +426,7 @@ func ExampleContext_Dict() {
 			Int("n", 1),
 		).Logger()
 
-	log.Log().Msg("hello world")
+	log.Log().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","dict":{"bar":"baz","n":1},"message":"hello world"}
@@ -424,7 +441,7 @@ func ExampleContext_Array() {
 			Int(1),
 		).Logger()
 
-	log.Log().Msg("hello world")
+	log.Log().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","array":["baz",1],"message":"hello world"}
@@ -443,7 +460,7 @@ func ExampleContext_Array_object() {
 		Array("users", u).
 		Logger()
 
-	log.Log().Msg("hello world")
+	log.Log().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","users":[{"name":"John","age":35,"created":"0001-01-01T00:00:00Z"},{"name":"Bob","age":55,"created":"0001-01-01T00:00:00Z"}],"message":"hello world"}
@@ -474,7 +491,7 @@ func ExampleContext_EmbedObject() {
 		EmbedObject(price).
 		Logger()
 
-	log.Log().Msg("hello world")
+	log.Log().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","price":"$64.49","message":"hello world"}
@@ -489,7 +506,7 @@ func ExampleContext_Object() {
 		Object("user", u).
 		Logger()
 
-	log.Log().Msg("hello world")
+	log.Log().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","user":{"name":"John","age":35,"created":"0001-01-01T00:00:00Z"},"message":"hello world"}
@@ -508,7 +525,7 @@ func ExampleContext_Interface() {
 		Interface("obj", obj).
 		Logger()
 
-	log.Log().Msg("hello world")
+	log.Log().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","obj":{"name":"john"},"message":"hello world"}
@@ -523,7 +540,7 @@ func ExampleContext_Dur() {
 		Dur("dur", d).
 		Logger()
 
-	log.Log().Msg("hello world")
+	log.Log().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","dur":10000,"message":"hello world"}
@@ -541,7 +558,7 @@ func ExampleContext_Durs() {
 		Durs("durs", d).
 		Logger()
 
-	log.Log().Msg("hello world")
+	log.Log().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","durs":[10000,20000],"message":"hello world"}
@@ -559,7 +576,7 @@ func ExampleContext_Fields_map() {
 		Fields(fields).
 		Logger()
 
-	log.Log().Msg("hello world")
+	log.Log().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
@@ -577,7 +594,7 @@ func ExampleContext_Fields_slice() {
 		Fields(fields).
 		Logger()
 
-	log.Log().Msg("hello world")
+	log.Log().LogLevel().Msg("hello world")
 
 	fmt.Println(decodeIfBinaryToString(dst.Bytes()))
 	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}

--- a/context.go
+++ b/context.go
@@ -431,3 +431,12 @@ func (c Context) MACAddr(key string, ha net.HardwareAddr) Context {
 	c.l.context = enc.AppendMACAddr(enc.AppendKey(c.l.context, key), ha)
 	return c
 }
+
+// LogLevel explicitly adds the key "level" with log level as string as value,
+// replaces if the key-value pair(s) already exists
+func (c Context) LogLevel() Context {
+	bufRemoveLevelItems(&c.l.context)
+	key := enc.AppendKey(c.l.context, LevelFieldName)
+	c.l.context = enc.AppendStringer(key, c.l.level)
+	return c
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,42 @@
+package zerolog
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestContext_LogLevel(t *testing.T) {
+	levels := []Level{
+		TraceLevel,
+		DebugLevel,
+		InfoLevel,
+		WarnLevel,
+		ErrorLevel,
+		FatalLevel,
+		PanicLevel,
+		NoLevel,
+		Disabled,
+	}
+
+	for _, l := range levels {
+		t.Run(l.String(), func(t *testing.T) {
+			out := &bytes.Buffer{}
+			log := New(out).With().Logger().Level(l)
+			log.UpdateContext(func(c Context) Context {
+				return c.LogLevel()
+			})
+			log.Log().Msg("test")
+
+			if l == Disabled {
+				if got := decodeIfBinaryToString(out.Bytes()); got != `` {
+					t.Errorf("invalid log output:\ngot:  %v\nwant: ", got)
+				}
+				return
+			}
+			if got, want := decodeIfBinaryToString(out.Bytes()), fmt.Sprintf(`{"level":"%s","message":"test"}`+"\n", l); got != want {
+				t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+			}
+		})
+	}
+}

--- a/event.go
+++ b/event.go
@@ -778,3 +778,16 @@ func (e *Event) MACAddr(key string, ha net.HardwareAddr) *Event {
 	e.buf = enc.AppendMACAddr(enc.AppendKey(e.buf, key), ha)
 	return e
 }
+
+// LogLevel explicitly adds the key "level" with log level as string as value,
+// replaces if the key-value pair(s) already exists
+func (e *Event) LogLevel() *Event {
+	if e == nil {
+		return e
+	}
+
+	bufRemoveLevelItems(&e.buf)
+	key := enc.AppendKey(e.buf, LevelFieldName)
+	e.buf = enc.AppendStringer(key, e.level)
+	return e
+}

--- a/globals.go
+++ b/globals.go
@@ -2,6 +2,7 @@ package zerolog
 
 import (
 	"encoding/json"
+	"regexp"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -108,6 +109,12 @@ var (
 	// DefaultContextLogger is returned from Ctx() if there is no logger associated
 	// with the context.
 	DefaultContextLogger *Logger
+
+	// LevelItemPattern regex matches the level key-value pair if already added to buffer
+	// Example: In the following string:
+	// 	{"level":"trace", "time":"2022-07-24T14:00:26+05:30","message":"text here", "level":"info"}
+	// this pattern matches `"level":"trace",` and `"level":"info"`
+	LevelItemPattern = regexp.MustCompile(`"level":"[a-z]{4,5}",?`)
 )
 
 var (
@@ -139,4 +146,9 @@ func DisableSampling(v bool) {
 
 func samplingDisabled() bool {
 	return atomic.LoadInt32(disableSampling) == 1
+}
+
+// bufRemoveLevelItems removes all byte strings that match LevelItemPattern from buf
+func bufRemoveLevelItems(buf *[]byte) {
+	*buf = LevelItemPattern.ReplaceAll(*buf, nil)
 }

--- a/log.go
+++ b/log.go
@@ -312,6 +312,19 @@ func (l Logger) Hook(h Hook) Logger {
 	return l
 }
 
+// LogLevel explicitly adds the key "level" with log level as string as value,
+// replaces if the key-value pair(s) already exists
+func (l Logger) LogLevel() *Logger {
+	if l.context == nil {
+		return &l
+	}
+
+	bufRemoveLevelItems(&l.context)
+	key := enc.AppendKey(l.context, LevelFieldName)
+	l.context = enc.AppendStringer(key, l.level)
+	return &l
+}
+
 // Trace starts a new message with trace level.
 //
 // You must call Msg on the returned event in order to send the event.

--- a/log_example_test.go
+++ b/log_example_test.go
@@ -1,3 +1,4 @@
+//go:build !binary_log
 // +build !binary_log
 
 package zerolog_test
@@ -16,7 +17,7 @@ import (
 func ExampleNew() {
 	log := zerolog.New(os.Stdout)
 
-	log.Info().Msg("hello world")
+	log.Info().LogLevel().Msg("hello world")
 	// Output: {"level":"info","message":"hello world"}
 }
 
@@ -26,16 +27,16 @@ func ExampleLogger_With() {
 		Str("foo", "bar").
 		Logger()
 
-	log.Info().Msg("hello world")
+	log.Info().LogLevel().Msg("hello world")
 
-	// Output: {"level":"info","foo":"bar","message":"hello world"}
+	// Output: {"foo":"bar","level":"info","message":"hello world"}
 }
 
 func ExampleLogger_Level() {
 	log := zerolog.New(os.Stdout).Level(zerolog.WarnLevel)
 
-	log.Info().Msg("filtered out message")
-	log.Error().Msg("kept message")
+	log.Info().LogLevel().Msg("filtered out message")
+	log.Error().LogLevel().Msg("kept message")
 
 	// Output: {"level":"error","message":"kept message"}
 }
@@ -43,10 +44,10 @@ func ExampleLogger_Level() {
 func ExampleLogger_Sample() {
 	log := zerolog.New(os.Stdout).Sample(&zerolog.BasicSampler{N: 2})
 
-	log.Info().Msg("message 1")
-	log.Info().Msg("message 2")
-	log.Info().Msg("message 3")
-	log.Info().Msg("message 4")
+	log.Info().LogLevel().Msg("message 1")
+	log.Info().LogLevel().Msg("message 2")
+	log.Info().LogLevel().Msg("message 3")
+	log.Info().LogLevel().Msg("message 4")
 
 	// Output: {"level":"info","message":"message 1"}
 	// {"level":"info","message":"message 3"}
@@ -74,13 +75,15 @@ func ExampleLogger_Hook() {
 
 	log := zerolog.New(os.Stdout).Hook(levelNameHook).Hook(messageHook)
 
-	log.Info().Msg("hello world")
+	log.Info().
+		LogLevel().
+		Msg("hello world")
 
 	// Output: {"level":"info","level_name":"info","the_message":"hello world","message":"hello world"}
 }
 
 func ExampleLogger_Print() {
-	log := zerolog.New(os.Stdout)
+	log := zerolog.New(os.Stdout).LogLevel()
 
 	log.Print("hello world")
 
@@ -88,7 +91,7 @@ func ExampleLogger_Print() {
 }
 
 func ExampleLogger_Printf() {
-	log := zerolog.New(os.Stdout)
+	log := zerolog.New(os.Stdout).LogLevel()
 
 	log.Printf("hello %s", "world")
 
@@ -101,9 +104,10 @@ func ExampleLogger_Trace() {
 	log.Trace().
 		Str("foo", "bar").
 		Int("n", 123).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"level":"trace","foo":"bar","n":123,"message":"hello world"}
+	// Output: {"foo":"bar","n":123,"level":"trace","message":"hello world"}
 }
 
 func ExampleLogger_Debug() {
@@ -112,9 +116,10 @@ func ExampleLogger_Debug() {
 	log.Debug().
 		Str("foo", "bar").
 		Int("n", 123).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"level":"debug","foo":"bar","n":123,"message":"hello world"}
+	// Output: {"foo":"bar","n":123,"level":"debug","message":"hello world"}
 }
 
 func ExampleLogger_Info() {
@@ -123,9 +128,10 @@ func ExampleLogger_Info() {
 	log.Info().
 		Str("foo", "bar").
 		Int("n", 123).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"level":"info","foo":"bar","n":123,"message":"hello world"}
+	// Output: {"foo":"bar","n":123,"level":"info","message":"hello world"}
 }
 
 func ExampleLogger_Warn() {
@@ -133,9 +139,10 @@ func ExampleLogger_Warn() {
 
 	log.Warn().
 		Str("foo", "bar").
+		LogLevel().
 		Msg("a warning message")
 
-	// Output: {"level":"warn","foo":"bar","message":"a warning message"}
+	// Output: {"foo":"bar","level":"warn","message":"a warning message"}
 }
 
 func ExampleLogger_Error() {
@@ -143,15 +150,17 @@ func ExampleLogger_Error() {
 
 	log.Error().
 		Err(errors.New("some error")).
+		LogLevel().
 		Msg("error doing something")
 
-	// Output: {"level":"error","error":"some error","message":"error doing something"}
+	// Output: {"error":"some error","level":"error","message":"error doing something"}
 }
 
 func ExampleLogger_WithLevel() {
 	log := zerolog.New(os.Stdout)
 
 	log.WithLevel(zerolog.InfoLevel).
+		LogLevel().
 		Msg("hello world")
 
 	// Output: {"level":"info","message":"hello world"}
@@ -160,6 +169,7 @@ func ExampleLogger_WithLevel() {
 func ExampleLogger_Write() {
 	log := zerolog.New(os.Stdout).With().
 		Str("foo", "bar").
+		LogLevel().
 		Logger()
 
 	stdlog.SetFlags(0)
@@ -167,7 +177,7 @@ func ExampleLogger_Write() {
 
 	stdlog.Print("hello world")
 
-	// Output: {"foo":"bar","message":"hello world"}
+	// Output: {"foo":"bar","level":"trace","message":"hello world"}
 }
 
 func ExampleLogger_Log() {
@@ -176,9 +186,10 @@ func ExampleLogger_Log() {
 	log.Log().
 		Str("foo", "bar").
 		Str("bar", "baz").
+		LogLevel().
 		Msg("")
 
-	// Output: {"foo":"bar","bar":"baz"}
+	// Output: {"foo":"bar","bar":"baz","level":""}
 }
 
 func ExampleEvent_Dict() {
@@ -190,9 +201,10 @@ func ExampleEvent_Dict() {
 			Str("bar", "baz").
 			Int("n", 1),
 		).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"foo":"bar","dict":{"bar":"baz","n":1},"message":"hello world"}
+	// Output: {"foo":"bar","dict":{"bar":"baz","n":1},"level":"","message":"hello world"}
 }
 
 type User struct {
@@ -244,9 +256,10 @@ func ExampleEvent_Array() {
 				Int("n", 1),
 			),
 		).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"foo":"bar","array":["baz",1,{"bar":"baz","n":1}],"message":"hello world"}
+	// Output: {"foo":"bar","array":["baz",1,{"bar":"baz","n":1}],"level":"","message":"hello world"}
 }
 
 func ExampleEvent_Array_object() {
@@ -261,9 +274,10 @@ func ExampleEvent_Array_object() {
 	log.Log().
 		Str("foo", "bar").
 		Array("users", u).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"foo":"bar","users":[{"name":"John","age":35,"created":"0001-01-01T00:00:00Z"},{"name":"Bob","age":55,"created":"0001-01-01T00:00:00Z"}],"message":"hello world"}
+	// Output: {"foo":"bar","users":[{"name":"John","age":35,"created":"0001-01-01T00:00:00Z"},{"name":"Bob","age":55,"created":"0001-01-01T00:00:00Z"}],"level":"","message":"hello world"}
 }
 
 func ExampleEvent_Object() {
@@ -275,9 +289,10 @@ func ExampleEvent_Object() {
 	log.Log().
 		Str("foo", "bar").
 		Object("user", u).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"foo":"bar","user":{"name":"John","age":35,"created":"0001-01-01T00:00:00Z"},"message":"hello world"}
+	// Output: {"foo":"bar","user":{"name":"John","age":35,"created":"0001-01-01T00:00:00Z"},"level":"","message":"hello world"}
 }
 
 func ExampleEvent_EmbedObject() {
@@ -288,9 +303,10 @@ func ExampleEvent_EmbedObject() {
 	log.Log().
 		Str("foo", "bar").
 		EmbedObject(price).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"foo":"bar","price":"$64.49","message":"hello world"}
+	// Output: {"foo":"bar","price":"$64.49","level":"","message":"hello world"}
 }
 
 func ExampleEvent_Interface() {
@@ -305,9 +321,10 @@ func ExampleEvent_Interface() {
 	log.Log().
 		Str("foo", "bar").
 		Interface("obj", obj).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"foo":"bar","obj":{"name":"john"},"message":"hello world"}
+	// Output: {"foo":"bar","obj":{"name":"john"},"level":"","message":"hello world"}
 }
 
 func ExampleEvent_Dur() {
@@ -318,9 +335,10 @@ func ExampleEvent_Dur() {
 	log.Log().
 		Str("foo", "bar").
 		Dur("dur", d).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"foo":"bar","dur":10000,"message":"hello world"}
+	// Output: {"foo":"bar","dur":10000,"level":"","message":"hello world"}
 }
 
 func ExampleEvent_Durs() {
@@ -334,9 +352,10 @@ func ExampleEvent_Durs() {
 	log.Log().
 		Str("foo", "bar").
 		Durs("durs", d).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"foo":"bar","durs":[10000,20000],"message":"hello world"}
+	// Output: {"foo":"bar","durs":[10000,20000],"level":"","message":"hello world"}
 }
 
 func ExampleEvent_Fields_map() {
@@ -350,9 +369,10 @@ func ExampleEvent_Fields_map() {
 	log.Log().
 		Str("foo", "bar").
 		Fields(fields).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+	// Output: {"foo":"bar","bar":"baz","n":1,"level":"","message":"hello world"}
 }
 
 func ExampleEvent_Fields_slice() {
@@ -366,9 +386,10 @@ func ExampleEvent_Fields_slice() {
 	log.Log().
 		Str("foo", "bar").
 		Fields(fields).
+		LogLevel().
 		Msg("hello world")
 
-	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+	// Output: {"foo":"bar","bar":"baz","n":1,"level":"","message":"hello world"}
 }
 
 func ExampleContext_Dict() {
@@ -377,11 +398,12 @@ func ExampleContext_Dict() {
 		Dict("dict", zerolog.Dict().
 			Str("bar", "baz").
 			Int("n", 1),
-		).Logger()
+		).Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"foo":"bar","dict":{"bar":"baz","n":1},"message":"hello world"}
+	// Output: {"foo":"bar","dict":{"bar":"baz","n":1},"level":"trace","message":"hello world"}
 }
 
 func ExampleContext_Array() {
@@ -390,11 +412,12 @@ func ExampleContext_Array() {
 		Array("array", zerolog.Arr().
 			Str("baz").
 			Int(1),
-		).Logger()
+		).Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"foo":"bar","array":["baz",1],"message":"hello world"}
+	// Output: {"foo":"bar","array":["baz",1],"level":"trace","message":"hello world"}
 }
 
 func ExampleContext_Array_object() {
@@ -407,11 +430,12 @@ func ExampleContext_Array_object() {
 	log := zerolog.New(os.Stdout).With().
 		Str("foo", "bar").
 		Array("users", u).
-		Logger()
+		Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"foo":"bar","users":[{"name":"John","age":35,"created":"0001-01-01T00:00:00Z"},{"name":"Bob","age":55,"created":"0001-01-01T00:00:00Z"}],"message":"hello world"}
+	// Output: {"foo":"bar","users":[{"name":"John","age":35,"created":"0001-01-01T00:00:00Z"},{"name":"Bob","age":55,"created":"0001-01-01T00:00:00Z"}],"level":"trace","message":"hello world"}
 }
 
 func ExampleContext_Object() {
@@ -421,11 +445,12 @@ func ExampleContext_Object() {
 	log := zerolog.New(os.Stdout).With().
 		Str("foo", "bar").
 		Object("user", u).
-		Logger()
+		Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"foo":"bar","user":{"name":"John","age":35,"created":"0001-01-01T00:00:00Z"},"message":"hello world"}
+	// Output: {"foo":"bar","user":{"name":"John","age":35,"created":"0001-01-01T00:00:00Z"},"level":"trace","message":"hello world"}
 }
 
 func ExampleContext_EmbedObject() {
@@ -435,11 +460,12 @@ func ExampleContext_EmbedObject() {
 	log := zerolog.New(os.Stdout).With().
 		Str("foo", "bar").
 		EmbedObject(price).
-		Logger()
+		Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"foo":"bar","price":"$64.49","message":"hello world"}
+	// Output: {"foo":"bar","price":"$64.49","level":"trace","message":"hello world"}
 }
 
 func ExampleContext_Interface() {
@@ -452,11 +478,12 @@ func ExampleContext_Interface() {
 	log := zerolog.New(os.Stdout).With().
 		Str("foo", "bar").
 		Interface("obj", obj).
-		Logger()
+		Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"foo":"bar","obj":{"name":"john"},"message":"hello world"}
+	// Output: {"foo":"bar","obj":{"name":"john"},"level":"trace","message":"hello world"}
 }
 
 func ExampleContext_Dur() {
@@ -465,11 +492,12 @@ func ExampleContext_Dur() {
 	log := zerolog.New(os.Stdout).With().
 		Str("foo", "bar").
 		Dur("dur", d).
-		Logger()
+		Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"foo":"bar","dur":10000,"message":"hello world"}
+	// Output: {"foo":"bar","dur":10000,"level":"trace","message":"hello world"}
 }
 
 func ExampleContext_Durs() {
@@ -481,44 +509,48 @@ func ExampleContext_Durs() {
 	log := zerolog.New(os.Stdout).With().
 		Str("foo", "bar").
 		Durs("durs", d).
-		Logger()
+		Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"foo":"bar","durs":[10000,20000],"message":"hello world"}
+	// Output: {"foo":"bar","durs":[10000,20000],"level":"trace","message":"hello world"}
 }
 
 func ExampleContext_IPAddr() {
 	hostIP := net.IP{192, 168, 0, 100}
 	log := zerolog.New(os.Stdout).With().
 		IPAddr("HostIP", hostIP).
-		Logger()
+		Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"HostIP":"192.168.0.100","message":"hello world"}
+	// Output: {"HostIP":"192.168.0.100","level":"trace","message":"hello world"}
 }
 
 func ExampleContext_IPPrefix() {
 	route := net.IPNet{IP: net.IP{192, 168, 0, 0}, Mask: net.CIDRMask(24, 32)}
 	log := zerolog.New(os.Stdout).With().
 		IPPrefix("Route", route).
-		Logger()
+		Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"Route":"192.168.0.0/24","message":"hello world"}
+	// Output: {"Route":"192.168.0.0/24","level":"trace","message":"hello world"}
 }
 
 func ExampleContext_MACAddr() {
 	mac := net.HardwareAddr{0x00, 0x14, 0x22, 0x01, 0x23, 0x45}
 	log := zerolog.New(os.Stdout).With().
 		MACAddr("hostMAC", mac).
-		Logger()
+		Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"hostMAC":"00:14:22:01:23:45","message":"hello world"}
+	// Output: {"hostMAC":"00:14:22:01:23:45","level":"trace","message":"hello world"}
 }
 
 func ExampleContext_Fields_map() {
@@ -530,11 +562,11 @@ func ExampleContext_Fields_map() {
 	log := zerolog.New(os.Stdout).With().
 		Str("foo", "bar").
 		Fields(fields).
-		Logger()
+		Logger().LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+	// Output: {"foo":"bar","bar":"baz","n":1,"level":"trace","message":"hello world"}
 }
 
 func ExampleContext_Fields_slice() {
@@ -546,9 +578,10 @@ func ExampleContext_Fields_slice() {
 	log := zerolog.New(os.Stdout).With().
 		Str("foo", "bar").
 		Fields(fields).
-		Logger()
+		Logger().
+		LogLevel()
 
 	log.Log().Msg("hello world")
 
-	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+	// Output: {"foo":"bar","bar":"baz","n":1,"level":"trace","message":"hello world"}
 }


### PR DESCRIPTION
Field `LogLevel` explicitly adds/replaces the log level to logs as per previous `Logger`, `Context` or `Event`. This only helps in printing and not changing log level.

1. If the item with key `level` doesn't exist, `LogLevel` will add new with log level string as value.
2. If `level` already exists but value differs, this will replace value.
3. If both key and value match, no change.

This will help in closing #398 