### PR TITLE
pass program counter to CallerMarshalFunc

### DIFF
--- a/event.go
+++ b/event.go
@@ -744,11 +744,11 @@ func (e *Event) caller(skip int) *Event {
 	if e == nil {
 		return e
 	}
-	_, file, line, ok := runtime.Caller(skip + e.skipFrame)
+	pc, file, line, ok := runtime.Caller(skip + e.skipFrame)
 	if !ok {
 		return e
 	}
-	e.buf = enc.AppendString(enc.AppendKey(e.buf, CallerFieldName), CallerMarshalFunc(file, line))
+	e.buf = enc.AppendString(enc.AppendKey(e.buf, CallerFieldName), CallerMarshalFunc(pc, file, line))
 	return e
 }
 

--- a/globals.go
+++ b/globals.go
@@ -65,7 +65,7 @@ var (
 	CallerSkipFrameCount = 2
 
 	// CallerMarshalFunc allows customization of global caller marshaling
-	CallerMarshalFunc = func(file string, line int) string {
+	CallerMarshalFunc = func(pc uintptr, file string, line int) string {
 		return file + ":" + strconv.Itoa(line)
 	}
 

--- a/log_test.go
+++ b/log_test.go
@@ -799,7 +799,7 @@ func TestCallerMarshalFunc(t *testing.T) {
 			return strings.Join(parts[len(parts)-2:], "/") + ":" + strconv.Itoa(line)
 		}
 
-		return file + ":" + strconv.Itoa(line) + " " + runtime.FuncForPC(pc).Name()
+		return runtime.FuncForPC(pc).Name() + ":" + file + ":" + strconv.Itoa(line)
 	}
 	pc, file, line, _ = runtime.Caller(0)
 	caller = CallerMarshalFunc(pc, file, line+2)

--- a/log_test.go
+++ b/log_test.go
@@ -782,7 +782,7 @@ func TestCallerMarshalFunc(t *testing.T) {
 
 	// test default behaviour this is really brittle due to the line numbers
 	// actually mattering for validation
-	_, file, line, _ := runtime.Caller(0)
+	pc, file, line, _ := runtime.Caller(0)
 	caller := fmt.Sprintf("%s:%d", file, line+2)
 	log.Log().Caller().Msg("msg")
 	if got, want := decodeIfBinaryToString(out.Bytes()), `{"caller":"`+caller+`","message":"msg"}`+"\n"; got != want {
@@ -793,16 +793,16 @@ func TestCallerMarshalFunc(t *testing.T) {
 	// test custom behavior. In this case we'll take just the last directory
 	origCallerMarshalFunc := CallerMarshalFunc
 	defer func() { CallerMarshalFunc = origCallerMarshalFunc }()
-	CallerMarshalFunc = func(file string, line int) string {
+	CallerMarshalFunc = func(pc uintptr, file string, line int) string {
 		parts := strings.Split(file, "/")
 		if len(parts) > 1 {
 			return strings.Join(parts[len(parts)-2:], "/") + ":" + strconv.Itoa(line)
 		}
 
-		return file + ":" + strconv.Itoa(line)
+		return file + ":" + strconv.Itoa(line) + " " + runtime.FuncForPC(pc).Name()
 	}
-	_, file, line, _ = runtime.Caller(0)
-	caller = CallerMarshalFunc(file, line+2)
+	pc, file, line, _ = runtime.Caller(0)
+	caller = CallerMarshalFunc(pc, file, line+2)
 	log.Log().Caller().Msg("msg")
 	if got, want := decodeIfBinaryToString(out.Bytes()), `{"caller":"`+caller+`","message":"msg"}`+"\n"; got != want {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)


### PR DESCRIPTION
This passes the pc var to marshallers to be able to add function names to caller fields.

This is a breaking change for those that have overridden `CallerMarshalFunc`  before, as the func signature changes.

All tests passed locally.

Resolves #456