### PR TITLE
Add Prehook and Pretimestamp features: this allows "time" key come first

### DIFF
--- a/context.go
+++ b/context.go
@@ -338,6 +338,16 @@ func (c Context) Timestamp() Context {
 	return c
 }
 
+// Pretimestamp adds the timestamp to the logger like `Timestamp` does.
+// It adds the "time" key before "level" key. Useful when sorting logs as text in time-order.
+//
+// NOTE: It adds timestamp not when sending log, but when starting a new message.
+// NOTE: Applying both `Timestamp()` and `PreTimestamp()`results duplicated "time" keys.
+func (c Context) Pretimestamp() Context {
+	c.l = c.l.Prehook(th)
+	return c
+}
+
 // Time adds the field key with t formated as string using zerolog.TimeFieldFormat.
 func (c Context) Time(key string, t time.Time) Context {
 	c.l.context = enc.AppendTime(enc.AppendKey(c.l.context, key), t, TimeFieldFormat)


### PR DESCRIPTION
Multiple log files can be sorted with `sort` if "time" key comes first.
For example:

```
$ cat node1.log nod2.log node3.log | sort
{"time":"2022-08-06T08:02:01Z","level":"info","node":"node1","message":"foo"}
{"time":"2022-08-06T08:02:12Z","level":"info","node":"node2","message":"bar"}
{"time":"2022-08-06T08:03:03Z","level":"info","node":"node1","message":"bar"}
{"time":"2022-08-06T08:03:10Z","level":"info","node":"node3","message":"bar"}
...
```

It would be useful in environments where logs aren't managed with log managing systems like Google Cloud Logging, AWS CloudWatch, and so on.


What I did:

* I added `Prehook()` feature. It calls hooks just before "level" is added to the buffer.
* I added `Pretimestamp()` feature. It adds timestamp hook with `Prehook`.

