### PR TITLE
ConsoleWriter: Show original level message if it's not predefined value.

### DIFF
--- a/console.go
+++ b/console.go
@@ -385,7 +385,7 @@ func consoleDefaultFormatLevel(noColor bool) Formatter {
 			case LevelPanicValue:
 				l = colorize(colorize("PNC", colorRed, noColor), colorBold, noColor)
 			default:
-				l = colorize("???", colorBold, noColor)
+				l = colorize(ll, colorBold, noColor)
 			}
 		} else {
 			if i == nil {


### PR DESCRIPTION
Currently ConsoleWriter shows `???` when the level doesn't match with any predefined values, but it would be better to show the original value instead of `???` because level could be changed by user with `zerolog.LevelFieldMarshalFunc`.

