### PR TITLE
Avoid race in diode.Close with waiter

### DIFF
--- a/diode/diode_test.go
+++ b/diode/diode_test.go
@@ -30,6 +30,14 @@ func TestNewWriter(t *testing.T) {
 	}
 }
 
+func TestClose(t *testing.T) {
+	buf := bytes.Buffer{}
+	w := diode.NewWriter(&buf, 1000, 0, func(missed int) {})
+	log := zerolog.New(w)
+	log.Print("test")
+	w.Close()
+}
+
 func Benchmark(b *testing.B) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stderr)

--- a/diode/internal/diodes/waiter.go
+++ b/diode/internal/diodes/waiter.go
@@ -39,7 +39,12 @@ func NewWaiter(d Diode, opts ...WaiterConfigOption) *Waiter {
 
 	go func() {
 		<-w.ctx.Done()
+
+		// Mutex is strictly necessary here to avoid a race in Next() (between
+		// w.isDone() and w.c.Wait()) and w.c.Broadcast() here.
+		w.mu.Lock()
 		w.c.Broadcast()
+		w.mu.Unlock()
 	}()
 
 	return w


### PR DESCRIPTION
In about 5% of instances of

    go test -count 100000 -run TestClose -timeout 30s .

the test ends in a deadlock:

    panic: test timed out after 30s

    goroutine 6465 [running]:
    testing.(*M).startAlarm.func1()
            /home/ddn/.conda/envs/katana-dev/go/src/testing/testing.go:2029 +0x8e
    created by time.goFunc
            /home/ddn/.conda/envs/katana-dev/go/src/time/sleep.go:176 +0x32

    goroutine 1 [chan receive]:
    testing.(*T).Run(0xc000636000, {0x54a7e4?, 0x4bba45?}, 0x555b78)
            /home/ddn/.conda/envs/katana-dev/go/src/testing/testing.go:1487 +0x37a
    testing.runTests.func1(0xc000636000?)
            /home/ddn/.conda/envs/katana-dev/go/src/testing/testing.go:1839 +0x6e
    testing.tRunner(0xc000636000, 0xc000069cd8)
            /home/ddn/.conda/envs/katana-dev/go/src/testing/testing.go:1439 +0x102
    testing.runTests(0xc0000a63c0?, {0x63b0e0, 0x2, 0x2}, {0x7fb6ff136108?, 0x40?, 0x643c00?})
            /home/ddn/.conda/envs/katana-dev/go/src/testing/testing.go:1837 +0x457
    testing.(*M).Run(0xc0000a63c0)
            /home/ddn/.conda/envs/katana-dev/go/src/testing/testing.go:1719 +0x5d9
    main.main()
            _testmain.go:55 +0x1aa

    goroutine 27226 [sync.Cond.Wait]:
    sync.runtime_notifyListWait(0xc00063a090, 0x0)
            /home/ddn/.conda/envs/katana-dev/go/src/runtime/sema.go:513 +0x13d
    sync.(*Cond).Wait(0xc00063a080?)
            /home/ddn/.conda/envs/katana-dev/go/src/sync/cond.go:56 +0x8c
    github.com/rs/zerolog/diode/internal/diodes.(*Waiter).Next(0xc0004ee090)
            /home/ddn/w/zerolog/diode/internal/diodes/waiter.go:69 +0x9b
    github.com/rs/zerolog/diode.Writer.poll({{0x57a600, 0xc0004ee060}, {0x57ae68, 0xc0004ee090}, 0xc000626040, 0xc000602120})
            /home/ddn/w/zerolog/diode/diode.go:96 +0x83
    created by github.com/rs/zerolog/diode.NewWriter
            /home/ddn/w/zerolog/diode/diode.go:70 +0x36f

    goroutine 27224 [chan receive]:
    github.com/rs/zerolog/diode.Writer.Close({{0x57a600, 0xc0004ee060}, {0x57ae68, 0xc0004ee090}, 0xc000626040, 0xc000602120})
            /home/ddn/w/zerolog/diode/diode.go:86 +0x4a
    github.com/rs/zerolog/diode_test.TestClose(0xc0006e6a00?)
            /home/ddn/w/zerolog/diode/diode_test.go:38 +0x1eb
    testing.tRunner(0xc0006361a0, 0x555b78)
            /home/ddn/.conda/envs/katana-dev/go/src/testing/testing.go:1439 +0x102
    created by testing.(*T).Run
            /home/ddn/.conda/envs/katana-dev/go/src/testing/testing.go:1486 +0x35f
    FAIL	github.com/rs/zerolog/diode	30.008s

This is due to a missed wakeup on Close. Avoid this by holding a mutex on Broadcast, which is not necessary in general but is necessary here.