### PR TITLE
feat: added support for go-errors stack traces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534
+	github.com/go-errors/errors v1.4.2
 	github.com/mattn/go-colorable v0.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/rs/xid v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534 h1:rtAn27wIbmOGUs7RIbVgPEjb31ehTVniDwPGXyMxm5U=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=

--- a/goerrors/stacktrace.go
+++ b/goerrors/stacktrace.go
@@ -1,0 +1,35 @@
+package goerrors
+
+import (
+	"path/filepath"
+	"strconv"
+
+	goerrors "github.com/go-errors/errors"
+)
+
+var (
+	StackSourceFileName     = "source"
+	StackSourceLineName     = "line"
+	StackSourceFunctionName = "func"
+)
+
+// MarshalStack implements go-errors stack trace marshaling.
+//
+// zerolog.ErrorStackMarshaler = MarshalStack
+func MarshalStack(err error) interface{} {
+	sterr, ok := err.(*goerrors.Error)
+	if !ok {
+		return nil
+	}
+	st := sterr.StackFrames()
+	out := make([]map[string]string, 0, len(st))
+	for _, frame := range st {
+		out = append(out, map[string]string{
+			StackSourceFileName:     filepath.Base(frame.File),
+			StackSourceLineName:     strconv.Itoa(frame.LineNumber),
+			StackSourceFunctionName: frame.Name,
+		})
+	}
+
+	return out
+}

--- a/goerrors/stacktrace_test.go
+++ b/goerrors/stacktrace_test.go
@@ -1,0 +1,58 @@
+//go:build !binary_log
+// +build !binary_log
+
+package goerrors
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	goerrors "github.com/go-errors/errors"
+	"github.com/rs/zerolog"
+)
+
+func TestLogStack(t *testing.T) {
+	zerolog.ErrorStackMarshaler = MarshalStack
+
+	out := &bytes.Buffer{}
+	log := zerolog.New(out)
+
+	err := goerrors.New("error message")
+	log.Log().Stack().Err(err).Msg("")
+
+	got := out.String()
+	want := `\{"stack":\[\{"func":"TestLogStack","line":"21","source":"stacktrace_test.go"\},.*\],"error":"error message"\}\n`
+	if ok, _ := regexp.MatchString(want, got); !ok {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestLogStackFromContext(t *testing.T) {
+	zerolog.ErrorStackMarshaler = MarshalStack
+
+	out := &bytes.Buffer{}
+	log := zerolog.New(out).With().Stack().Logger() // calling Stack() on log context instead of event
+
+	err := goerrors.New("error message")
+	log.Log().Err(err).Msg("") // not explicitly calling Stack()
+
+	got := out.String()
+	want := `\{"stack":\[\{"func":"TestLogStackFromContext","line":"37","source":"stacktrace_test.go"\},.*\],"error":"error message"\}\n`
+	if ok, _ := regexp.MatchString(want, got); !ok {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func BenchmarkGoErrorsLogStack(b *testing.B) {
+	zerolog.ErrorStackMarshaler = MarshalStack
+	out := &bytes.Buffer{}
+	log := zerolog.New(out)
+	err := goerrors.New("error message")
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		log.Log().Stack().Err(err).Msg("")
+		out.Reset()
+	}
+}


### PR DESCRIPTION
Added support to print out stack traces generated by the [go-errors](https://github.com/go-errors/errors) library.

I've put the new code in goerrors package, similar to the existing pkgerrors package, becase I wasn't sure what kind of folder structure would you prefer. If you want I can change this structure to something like:
```
stacktraces/{pkgerrors,goerrors}
```

Thank you for this library!