### PR TITLE
Fix docs and behavior of WithContext

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -2,6 +2,7 @@ package zerolog
 
 import (
 	"context"
+	"reflect"
 )
 
 var disabledLogger *Logger
@@ -32,7 +33,12 @@ type ctxKey struct{}
 //     })
 //
 func (l Logger) WithContext(ctx context.Context) context.Context {
-	if _, ok := ctx.Value(ctxKey{}).(*Logger); !ok && l.level == Disabled {
+	if lp, ok := ctx.Value(ctxKey{}).(*Logger); ok {
+		if reflect.DeepEqual(*lp, l) {
+			// Do not store same logger.
+			return ctx
+		}
+	} else if l.level == Disabled {
 		// Do not store disabled logger.
 		return ctx
 	}

--- a/ctx.go
+++ b/ctx.go
@@ -2,7 +2,6 @@ package zerolog
 
 import (
 	"context"
-	"reflect"
 )
 
 var disabledLogger *Logger
@@ -33,12 +32,7 @@ type ctxKey struct{}
 //     })
 //
 func (l Logger) WithContext(ctx context.Context) context.Context {
-	if lp, ok := ctx.Value(ctxKey{}).(*Logger); ok {
-		if reflect.DeepEqual(*lp, l) {
-			// Do not store same logger.
-			return ctx
-		}
-	} else if l.level == Disabled {
+	if _, ok := ctx.Value(ctxKey{}).(*Logger); !ok && l.level == Disabled {
 		// Do not store disabled logger.
 		return ctx
 	}


### PR DESCRIPTION
This change updates `WithContext` to better match documented behavior and also updates the documentation to both clarify existing behavior as well as the behavior expected by existing tests.

Note: since `WithContext` no longer employs a pointer receiver, the value comparison against the Context's attached logger value must be done via `reflect.DeepEqual`.

Fixes: #498 