### PR TITLE
Fix console formatter for TimeFormatUnixNano

### DIFF
--- a/console.go
+++ b/console.go
@@ -348,15 +348,19 @@ func consoleDefaultFormatTimestamp(timeFormat string, noColor bool) Formatter {
 			if err != nil {
 				t = tt.String()
 			} else {
-				var sec, nsec int64 = i, 0
+				var sec, nsec int64
+
 				switch TimeFieldFormat {
-				case TimeFormatUnixMs:
-					nsec = int64(time.Duration(i) * time.Millisecond)
-					sec = 0
+				case TimeFormatUnixNano:
+					sec, nsec = 0, i
 				case TimeFormatUnixMicro:
-					nsec = int64(time.Duration(i) * time.Microsecond)
-					sec = 0
+					sec, nsec = 0, int64(time.Duration(i)*time.Microsecond)
+				case TimeFormatUnixMs:
+					sec, nsec = 0, int64(time.Duration(i)*time.Millisecond)
+				default:
+					sec, nsec = i, 0
 				}
+
 				ts := time.Unix(sec, nsec)
 				t = ts.Format(timeFormat)
 			}


### PR DESCRIPTION
The existing code doesn't provide for the TimeFormatUnixNano case, and the default is to use the timestamp as seconds, not nanoseconds.  The following request preserves behavior for any case other than TimeFormatUnixNano, but fixes that case.