### PR TITLE
Add global ErrorStackFieldAfterErrorField to reverse stack and error order

### DIFF
--- a/event.go
+++ b/event.go
@@ -377,6 +377,9 @@ func (e *Event) Err(err error) *Event {
 	if e == nil {
 		return e
 	}
+	if ErrorStackFieldAfterErrorField {
+		e.AnErr(ErrorFieldName, err)
+	}
 	if e.stack && ErrorStackMarshaler != nil {
 		switch m := ErrorStackMarshaler(err).(type) {
 		case nil:
@@ -391,6 +394,9 @@ func (e *Event) Err(err error) *Event {
 		default:
 			e.Interface(ErrorStackFieldName, m)
 		}
+	}
+	if ErrorStackFieldAfterErrorField {
+		return e
 	}
 	return e.AnErr(ErrorFieldName, err)
 }

--- a/globals.go
+++ b/globals.go
@@ -75,6 +75,9 @@ var (
 	// ErrorStackMarshaler extract the stack from err if any.
 	ErrorStackMarshaler func(err error) interface{}
 
+	// ErrorStackFieldAfterErrorField results fields for error stacks come after error fields
+	ErrorStackFieldAfterErrorField = false
+
 	// ErrorMarshalFunc allows customization of global error marshaling
 	ErrorMarshalFunc = func(err error) interface{} {
 		return err


### PR DESCRIPTION
Stacktrace is enabled, and the output gets like this:

```
{"level":"error","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}],"error":"seems we have an error here","time":1609086683}
```

`"stack"` is often long and `"error"` comes to the later part of the log line.
I have difficulties for this behavior when using with datadog (https://www.datadoghq.com/): datadog sends error logs to monitoring devices (like mobile phone), but those logs are truncated with the beginning part of logs. Those logs are filled with stacktrace and I cannot see the most important "error" field there.

This pull request introduces `zerolog.ErrorStackFieldAfterErrorField`.
Setting `zerolog.ErrorStackFieldAfterErrorField = true` results log output like this:
```
{"level":"error","error":"seems we have an error here","stack":[{"func":"inner","line":"20","source":"errors.go"},{"func":"middle","line":"24","source":"errors.go"},{"func":"outer","line":"32","source":"errors.go"},{"func":"main","line":"15","source":"errors.go"},{"func":"main","line":"204","source":"proc.go"},{"func":"goexit","line":"1374","source":"asm_amd64.s"}],"time":1609086683}
```
You can find the error message easily.
