### PR TITLE
parsing CAPS log levels

### DIFF
--- a/log.go
+++ b/log.go
@@ -105,6 +105,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 )
 
 // Level defines log levels.
@@ -160,7 +161,7 @@ func (l Level) String() string {
 // ParseLevel converts a level string into a zerolog Level value.
 // returns an error if the input string does not match known values.
 func ParseLevel(levelStr string) (Level, error) {
-	switch levelStr {
+	switch strings.ToLower(levelStr) {
 	case LevelFieldMarshalFunc(TraceLevel):
 		return TraceLevel, nil
 	case LevelFieldMarshalFunc(DebugLevel):


### PR DESCRIPTION
Really tiny improvement that makes life better. Sometimes people use caps log levels, like INFO, WARN, etc. And it also makes sense, because in logs zerolog actually writes things like
```
Nov 11 13:19:51.738295 WARN ...
```
So, it can be not obvious that it will not parse WARN log level.