### PR TITLE
Replace duplicate 'append' text in doc comments

### DIFF
--- a/array.go
+++ b/array.go
@@ -57,7 +57,7 @@ func (a *Array) write(dst []byte) []byte {
 }
 
 // Object marshals an object that implement the LogObjectMarshaler
-// interface and append append it to the array.
+// interface and appends it to the array.
 func (a *Array) Object(obj LogObjectMarshaler) *Array {
 	e := Dict()
 	obj.MarshalZerologObject(e)
@@ -67,19 +67,19 @@ func (a *Array) Object(obj LogObjectMarshaler) *Array {
 	return a
 }
 
-// Str append append the val as a string to the array.
+// Str appends the val as a string to the array.
 func (a *Array) Str(val string) *Array {
 	a.buf = enc.AppendString(enc.AppendArrayDelim(a.buf), val)
 	return a
 }
 
-// Bytes append append the val as a string to the array.
+// Bytes appends the val as a string to the array.
 func (a *Array) Bytes(val []byte) *Array {
 	a.buf = enc.AppendBytes(enc.AppendArrayDelim(a.buf), val)
 	return a
 }
 
-// Hex append append the val as a hex string to the array.
+// Hex appends the val as a hex string to the array.
 func (a *Array) Hex(val []byte) *Array {
 	a.buf = enc.AppendHex(enc.AppendArrayDelim(a.buf), val)
 	return a
@@ -115,97 +115,97 @@ func (a *Array) Err(err error) *Array {
 	return a
 }
 
-// Bool append append the val as a bool to the array.
+// Bool appends the val as a bool to the array.
 func (a *Array) Bool(b bool) *Array {
 	a.buf = enc.AppendBool(enc.AppendArrayDelim(a.buf), b)
 	return a
 }
 
-// Int append append i as a int to the array.
+// Int appends i as a int to the array.
 func (a *Array) Int(i int) *Array {
 	a.buf = enc.AppendInt(enc.AppendArrayDelim(a.buf), i)
 	return a
 }
 
-// Int8 append append i as a int8 to the array.
+// Int8 appends i as a int8 to the array.
 func (a *Array) Int8(i int8) *Array {
 	a.buf = enc.AppendInt8(enc.AppendArrayDelim(a.buf), i)
 	return a
 }
 
-// Int16 append append i as a int16 to the array.
+// Int16 appends i as a int16 to the array.
 func (a *Array) Int16(i int16) *Array {
 	a.buf = enc.AppendInt16(enc.AppendArrayDelim(a.buf), i)
 	return a
 }
 
-// Int32 append append i as a int32 to the array.
+// Int32 appends i as a int32 to the array.
 func (a *Array) Int32(i int32) *Array {
 	a.buf = enc.AppendInt32(enc.AppendArrayDelim(a.buf), i)
 	return a
 }
 
-// Int64 append append i as a int64 to the array.
+// Int64 appends i as a int64 to the array.
 func (a *Array) Int64(i int64) *Array {
 	a.buf = enc.AppendInt64(enc.AppendArrayDelim(a.buf), i)
 	return a
 }
 
-// Uint append append i as a uint to the array.
+// Uint appends i as a uint to the array.
 func (a *Array) Uint(i uint) *Array {
 	a.buf = enc.AppendUint(enc.AppendArrayDelim(a.buf), i)
 	return a
 }
 
-// Uint8 append append i as a uint8 to the array.
+// Uint8 appends i as a uint8 to the array.
 func (a *Array) Uint8(i uint8) *Array {
 	a.buf = enc.AppendUint8(enc.AppendArrayDelim(a.buf), i)
 	return a
 }
 
-// Uint16 append append i as a uint16 to the array.
+// Uint16 appends i as a uint16 to the array.
 func (a *Array) Uint16(i uint16) *Array {
 	a.buf = enc.AppendUint16(enc.AppendArrayDelim(a.buf), i)
 	return a
 }
 
-// Uint32 append append i as a uint32 to the array.
+// Uint32 appends i as a uint32 to the array.
 func (a *Array) Uint32(i uint32) *Array {
 	a.buf = enc.AppendUint32(enc.AppendArrayDelim(a.buf), i)
 	return a
 }
 
-// Uint64 append append i as a uint64 to the array.
+// Uint64 appends i as a uint64 to the array.
 func (a *Array) Uint64(i uint64) *Array {
 	a.buf = enc.AppendUint64(enc.AppendArrayDelim(a.buf), i)
 	return a
 }
 
-// Float32 append append f as a float32 to the array.
+// Float32 appends f as a float32 to the array.
 func (a *Array) Float32(f float32) *Array {
 	a.buf = enc.AppendFloat32(enc.AppendArrayDelim(a.buf), f)
 	return a
 }
 
-// Float64 append append f as a float64 to the array.
+// Float64 appends f as a float64 to the array.
 func (a *Array) Float64(f float64) *Array {
 	a.buf = enc.AppendFloat64(enc.AppendArrayDelim(a.buf), f)
 	return a
 }
 
-// Time append append t formatted as string using zerolog.TimeFieldFormat.
+// Time appends t formatted as string using zerolog.TimeFieldFormat.
 func (a *Array) Time(t time.Time) *Array {
 	a.buf = enc.AppendTime(enc.AppendArrayDelim(a.buf), t, TimeFieldFormat)
 	return a
 }
 
-// Dur append append d to the array.
+// Dur appends d to the array.
 func (a *Array) Dur(d time.Duration) *Array {
 	a.buf = enc.AppendDuration(enc.AppendArrayDelim(a.buf), d, DurationFieldUnit, DurationFieldInteger)
 	return a
 }
 
-// Interface append append i marshaled using reflection.
+// Interface appends i marshaled using reflection.
 func (a *Array) Interface(i interface{}) *Array {
 	if obj, ok := i.(LogObjectMarshaler); ok {
 		return a.Object(obj)


### PR DESCRIPTION
Replace 'append append' with 'appends'.

This resolves what appears to be an unintentional search/replace action that occurred as part of other cleanup work.