### PR TITLE
feat: add `GetKeys` to get event keys

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,6 +1,7 @@
 package zerolog
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -791,4 +792,24 @@ func (e *Event) MACAddr(key string, ha net.HardwareAddr) *Event {
 	}
 	e.buf = enc.AppendMACAddr(enc.AppendKey(e.buf, key), ha)
 	return e
+}
+
+// GetKeys returns the keys of the event.
+// NOTE: This is an expensive operation and should be used sparingly.
+func (e *Event) GetKeys() ([]string, error) {
+	if e == nil {
+		return nil, nil
+	}
+
+	var event map[string]interface{}
+	if err := json.Unmarshal(e.buf, &event); err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0)
+	for key := range event {
+		keys = append(keys, key)
+	}
+
+	return keys, nil
 }

--- a/event_test.go
+++ b/event_test.go
@@ -1,3 +1,4 @@
+//go:build !binary_log
 // +build !binary_log
 
 package zerolog
@@ -61,5 +62,27 @@ func TestEvent_EmbedObjectWithNil(t *testing.T) {
 	got := strings.TrimSpace(buf.String())
 	if got != want {
 		t.Errorf("Event.EmbedObject() = %q, want %q", got, want)
+	}
+}
+
+func TestEvent_GetKeys(t *testing.T) {
+	var buf bytes.Buffer
+	e := newEvent(levelWriterAdapter{&buf}, DebugLevel)
+	e.Str("foo", "bar")
+	e.Int("baz", 42)
+	_ = e.write()
+
+	want := []string{"foo", "baz"}
+	got, err := e.GetKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Errorf("Event.GetKeys() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Event.GetKeys() = %v, want %v", got, want)
+		}
 	}
 }


### PR DESCRIPTION
As far as I know, there is no way to get all the keys of a particular event.
This is handy (even though expensive), to use in hooks.