### PR TITLE
Add support for logger-local error handlers

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -1,3 +1,4 @@
+//go:build !binary_log
 // +build !binary_log
 
 package zerolog

--- a/globals.go
+++ b/globals.go
@@ -101,8 +101,9 @@ var (
 	DurationFieldInteger = false
 
 	// ErrorHandler is called whenever zerolog fails to write an event on its
-	// output. If not set, an error is printed on the stderr. This handler must
-	// be thread safe and non-blocking.
+	// output, even if the logger has its own error handler configured. If not
+	// set, an error is printed on the stderr. This handler must be thread safe
+	// and non-blocking.
 	ErrorHandler func(err error)
 
 	// DefaultContextLogger is returned from Ctx() if there is no logger associated

--- a/log.go
+++ b/log.go
@@ -2,97 +2,96 @@
 //
 // A global Logger can be use for simple logging:
 //
-//     import "github.com/rs/zerolog/log"
+//	import "github.com/rs/zerolog/log"
 //
-//     log.Info().Msg("hello world")
-//     // Output: {"time":1494567715,"level":"info","message":"hello world"}
+//	log.Info().Msg("hello world")
+//	// Output: {"time":1494567715,"level":"info","message":"hello world"}
 //
 // NOTE: To import the global logger, import the "log" subpackage "github.com/rs/zerolog/log".
 //
 // Fields can be added to log messages:
 //
-//     log.Info().Str("foo", "bar").Msg("hello world")
-//     // Output: {"time":1494567715,"level":"info","message":"hello world","foo":"bar"}
+//	log.Info().Str("foo", "bar").Msg("hello world")
+//	// Output: {"time":1494567715,"level":"info","message":"hello world","foo":"bar"}
 //
 // Create logger instance to manage different outputs:
 //
-//     logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
-//     logger.Info().
-//            Str("foo", "bar").
-//            Msg("hello world")
-//     // Output: {"time":1494567715,"level":"info","message":"hello world","foo":"bar"}
+//	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+//	logger.Info().
+//	       Str("foo", "bar").
+//	       Msg("hello world")
+//	// Output: {"time":1494567715,"level":"info","message":"hello world","foo":"bar"}
 //
 // Sub-loggers let you chain loggers with additional context:
 //
-//     sublogger := log.With().Str("component": "foo").Logger()
-//     sublogger.Info().Msg("hello world")
-//     // Output: {"time":1494567715,"level":"info","message":"hello world","component":"foo"}
+//	sublogger := log.With().Str("component": "foo").Logger()
+//	sublogger.Info().Msg("hello world")
+//	// Output: {"time":1494567715,"level":"info","message":"hello world","component":"foo"}
 //
 // Level logging
 //
-//     zerolog.SetGlobalLevel(zerolog.InfoLevel)
+//	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 //
-//     log.Debug().Msg("filtered out message")
-//     log.Info().Msg("routed message")
+//	log.Debug().Msg("filtered out message")
+//	log.Info().Msg("routed message")
 //
-//     if e := log.Debug(); e.Enabled() {
-//         // Compute log output only if enabled.
-//         value := compute()
-//         e.Str("foo": value).Msg("some debug message")
-//     }
-//     // Output: {"level":"info","time":1494567715,"routed message"}
+//	if e := log.Debug(); e.Enabled() {
+//	    // Compute log output only if enabled.
+//	    value := compute()
+//	    e.Str("foo": value).Msg("some debug message")
+//	}
+//	// Output: {"level":"info","time":1494567715,"routed message"}
 //
 // Customize automatic field names:
 //
-//     log.TimestampFieldName = "t"
-//     log.LevelFieldName = "p"
-//     log.MessageFieldName = "m"
+//	log.TimestampFieldName = "t"
+//	log.LevelFieldName = "p"
+//	log.MessageFieldName = "m"
 //
-//     log.Info().Msg("hello world")
-//     // Output: {"t":1494567715,"p":"info","m":"hello world"}
+//	log.Info().Msg("hello world")
+//	// Output: {"t":1494567715,"p":"info","m":"hello world"}
 //
 // Log with no level and message:
 //
-//     log.Log().Str("foo","bar").Msg("")
-//     // Output: {"time":1494567715,"foo":"bar"}
+//	log.Log().Str("foo","bar").Msg("")
+//	// Output: {"time":1494567715,"foo":"bar"}
 //
 // Add contextual fields to global Logger:
 //
-//     log.Logger = log.With().Str("foo", "bar").Logger()
+//	log.Logger = log.With().Str("foo", "bar").Logger()
 //
 // Sample logs:
 //
-//     sampled := log.Sample(&zerolog.BasicSampler{N: 10})
-//     sampled.Info().Msg("will be logged every 10 messages")
+//	sampled := log.Sample(&zerolog.BasicSampler{N: 10})
+//	sampled.Info().Msg("will be logged every 10 messages")
 //
 // Log with contextual hooks:
 //
-//     // Create the hook:
-//     type SeverityHook struct{}
+//	// Create the hook:
+//	type SeverityHook struct{}
 //
-//     func (h SeverityHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
-//          if level != zerolog.NoLevel {
-//              e.Str("severity", level.String())
-//          }
-//     }
+//	func (h SeverityHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+//	     if level != zerolog.NoLevel {
+//	         e.Str("severity", level.String())
+//	     }
+//	}
 //
-//     // And use it:
-//     var h SeverityHook
-//     log := zerolog.New(os.Stdout).Hook(h)
-//     log.Warn().Msg("")
-//     // Output: {"level":"warn","severity":"warn"}
+//	// And use it:
+//	var h SeverityHook
+//	log := zerolog.New(os.Stdout).Hook(h)
+//	log.Warn().Msg("")
+//	// Output: {"level":"warn","severity":"warn"}
 //
-//
-// Caveats
+// # Caveats
 //
 // There is no fields deduplication out-of-the-box.
 // Using the same key multiple times creates new key in final JSON each time.
 //
-//     logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
-//     logger.Info().
-//            Timestamp().
-//            Msg("dup")
-//     // Output: {"level":"info","time":1494567715,"time":1494567715,"message":"dup"}
+//	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+//	logger.Info().
+//	       Timestamp().
+//	       Msg("dup")
+//	// Output: {"level":"info","time":1494567715,"time":1494567715,"message":"dup"}
 //
 // In this case, many consumers will take the last value,
 // but this is not guaranteed; check yours if in doubt.
@@ -215,6 +214,7 @@ type Logger struct {
 	w       LevelWriter
 	level   Level
 	sampler Sampler
+	eh      func(err error)
 	context []byte
 	hooks   []Hook
 	stack   bool
@@ -236,6 +236,18 @@ func New(w io.Writer) Logger {
 		lw = levelWriterAdapter{w}
 	}
 	return Logger{w: lw, level: TraceLevel}
+}
+
+// NewWithErrorHandler creates a root logger with given output writer. If the
+// output writer implements the LevelWriter interface, the WriteLevel method
+// will be called instead of the Write one.
+//
+// If the logger fails to write an event to its output, the error handler is
+// invoked.
+func NewWithErrorHandler(w io.Writer, eh func(err error)) Logger {
+	l := New(w)
+	l.eh = eh
+	return l
 }
 
 // Nop returns a disabled logger for which all operation are no-op.
@@ -451,6 +463,7 @@ func (l *Logger) newEvent(level Level, done func(string)) *Event {
 		return nil
 	}
 	e := newEvent(l.w, level)
+	e.eh = l.eh
 	e.done = done
 	e.ch = l.hooks
 	if level != NoLevel && LevelFieldName != "" {

--- a/log_test.go
+++ b/log_test.go
@@ -853,7 +853,7 @@ func (w errWriter) Write(p []byte) (n int, err error) {
 	return 0, w.error
 }
 
-func TestErrorHandler(t *testing.T) {
+func TestGlobalErrorHandler(t *testing.T) {
 	var got error
 	want := errors.New("write error")
 	ErrorHandler = func(err error) {
@@ -863,6 +863,38 @@ func TestErrorHandler(t *testing.T) {
 	log.Log().Msg("test")
 	if got != want {
 		t.Errorf("ErrorHandler err = %#v, want %#v", got, want)
+	}
+}
+
+func TestLocalErrorHandler(t *testing.T) {
+	var got error
+	want := errors.New("write error")
+	eh := func(err error) {
+		got = err
+	}
+	log := NewWithErrorHandler(errWriter{want}, eh)
+	log.Log().Msg("test")
+	if got != want {
+		t.Errorf("LocalErrorHandler err = %#v, want %#v", got, want)
+	}
+}
+
+func TestLocalAndGlobalErrorHandler(t *testing.T) {
+	var gotGlobal, gotLocal error
+	want := errors.New("write error")
+	ErrorHandler = func(err error) {
+		gotGlobal = err
+	}
+	eh := func(err error) {
+		gotLocal = err
+	}
+	log := NewWithErrorHandler(errWriter{want}, eh)
+	log.Log().Msg("test")
+	if gotGlobal != want {
+		t.Errorf("ErrorHandler err = %#v, want %#v", gotGlobal, want)
+	}
+	if gotLocal != want {
+		t.Errorf("LocalErrorHandler err = %#v, want %#v", gotLocal, want)
 	}
 }
 


### PR DESCRIPTION
There are some use cases for writing to zerolog from within the ErrorHandler, but today this is extremely tricky to do safely as it can easily lead to ErrorHandlers triggering ErrorHandlers (causing a log bomb). Logger-local error handlers allow us to configure eg. a primary logger with an ErrorHandler that calls a secondary logger with no ErrorHandler.

Event struct was rearranged to save space; gofmt adjusted some doc indenting in log.go.