### PR TITLE
Add Event.Size() method to return the size of the event buffer

### DIFF
--- a/event.go
+++ b/event.go
@@ -83,7 +83,7 @@ func (e *Event) write() (err error) {
 }
 
 // Size returns the size of the buffer in the Event.
-// This is most likely useful inside a Hook.
+// This is most likely only useful inside a Hook.
 func (e *Event) Size() int64 {
 	if e != nil {
 		return int64(len(e.buf))

--- a/event.go
+++ b/event.go
@@ -82,6 +82,24 @@ func (e *Event) write() (err error) {
 	return
 }
 
+// Buffer returns the underlying data buffer of the Event.
+// This is most likely useful inside a Hook.
+func (e *Event) Buffer() []byte {
+	if e != nil {
+		return e.buf
+	}
+	return nil
+}
+
+// Size returns the size of the buffer in the Event.
+// This is most likely useful inside a Hook.
+func (e *Event) Size() int64 {
+	if e != nil {
+		return int64(len(e.buf))
+	}
+	return 0
+}
+
 // Enabled return false if the *Event is going to be filtered out by
 // log level or sampling.
 func (e *Event) Enabled() bool {

--- a/event.go
+++ b/event.go
@@ -82,15 +82,6 @@ func (e *Event) write() (err error) {
 	return
 }
 
-// Buffer returns the underlying data buffer of the Event.
-// This is most likely useful inside a Hook.
-func (e *Event) Buffer() []byte {
-	if e != nil {
-		return e.buf
-	}
-	return nil
-}
-
 // Size returns the size of the buffer in the Event.
 // This is most likely useful inside a Hook.
 func (e *Event) Size() int64 {


### PR DESCRIPTION
I am writing a hook to increment some opentelemetry metrics in a logging library. One of the things I would like to count is the sum of bytes written. I can easily get the count of bytes for the "message" (as a parameter to the hook callback) but I want the entire event that will be written.

I wasn't sure if it would be preferable to return a zero or -1 in the case of a nil Event. Thoughts?