### PR TITLE
Correct logger variable name in stdout example

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ log.Ctx(ctx).Info().Msg("hello world")
 ### Set as standard logger output
 
 ```go
-log := zerolog.New(os.Stdout).With().
+stdlog := zerolog.New(os.Stdout).With().
     Str("foo", "bar").
     Logger()
 


### PR DESCRIPTION
Updates the logger variable name in the "Set as standard logger output" example so that its assignment is consistent with its invocation.