### PR TITLE
Fix docs for context.Timestamp

### DIFF
--- a/context.go
+++ b/context.go
@@ -329,8 +329,9 @@ func (ts timestampHook) Run(e *Event, level Level, msg string) {
 
 var th = timestampHook{}
 
-// Timestamp adds the current local time as UNIX timestamp to the logger context with the "time" key.
+// Timestamp adds the current local time to the logger context with the "time" key, formatted using zerolog.TimeFieldFormat.
 // To customize the key name, change zerolog.TimestampFieldName.
+// To customize the time format, change zerolog.TimeFieldFormat.
 //
 // NOTE: It won't dedupe the "time" key if the *Context has one already.
 func (c Context) Timestamp() Context {


### PR DESCRIPTION
Contrary to the documentation for `zerolog.Context.Timestamp`, the following does _not_ log timestamps in Unix format by default:

```go
log := zerolog.New(os.Stderr).With().Timestamp().Logger()
logger.Info().Msg("hello, world")
// output: {"level":"info","time":"2023-06-09T22:43:30-04:00","message":"hello world"}
```