### PR TITLE
Allow callers to pass go context through to hooks

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,6 +1,7 @@
 package zerolog
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"net"
@@ -160,6 +161,7 @@ func BenchmarkLogFieldType(b *testing.B) {
 		{"a", "a", 0},
 	}
 	errs := []error{errors.New("a"), errors.New("b"), errors.New("c"), errors.New("d"), errors.New("e")}
+	ctx := context.Background()
 	types := map[string]func(e *Event) *Event{
 		"Bool": func(e *Event) *Event {
 			return e.Bool("k", bools[0])
@@ -190,6 +192,9 @@ func BenchmarkLogFieldType(b *testing.B) {
 		},
 		"Errs": func(e *Event) *Event {
 			return e.Errs("k", errs)
+		},
+		"Ctx": func(e *Event) *Event {
+			return e.Ctx(ctx)
 		},
 		"Time": func(e *Event) *Event {
 			return e.Time("k", times[0])
@@ -284,6 +289,7 @@ func BenchmarkContextFieldType(b *testing.B) {
 		{"a", "a", 0},
 	}
 	errs := []error{errors.New("a"), errors.New("b"), errors.New("c"), errors.New("d"), errors.New("e")}
+	ctx := context.Background()
 	types := map[string]func(c Context) Context{
 		"Bool": func(c Context) Context {
 			return c.Bool("k", bools[0])
@@ -317,6 +323,9 @@ func BenchmarkContextFieldType(b *testing.B) {
 		},
 		"Errs": func(c Context) Context {
 			return c.Errs("k", errs)
+		},
+		"Ctx": func(c Context) Context {
+			return c.Ctx(ctx)
 		},
 		"Time": func(c Context) Context {
 			return c.Time("k", times[0])

--- a/context.go
+++ b/context.go
@@ -1,6 +1,7 @@
 package zerolog
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -163,6 +164,15 @@ func (c Context) Errs(key string, errs []error) Context {
 // Err adds the field "error" with serialized err to the logger context.
 func (c Context) Err(err error) Context {
 	return c.AnErr(ErrorFieldName, err)
+}
+
+// Ctx adds the context.Context to the logger context. The context.Context is
+// not rendered in the error message, but is made available for hooks to use.
+// A typical use case is to extract tracing information from the
+// context.Context.
+func (c Context) Ctx(ctx context.Context) Context {
+	c.l.ctx = ctx
+	return c
 }
 
 // Bool adds the field key with val as a bool to the logger context.

--- a/hook_test.go
+++ b/hook_test.go
@@ -2,9 +2,14 @@ package zerolog
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"testing"
 )
+
+type contextKeyType int
+
+var contextKey contextKeyType
 
 var (
 	levelNameHook = HookFunc(func(e *Event, level Level, msg string) {
@@ -30,6 +35,12 @@ var (
 	})
 	discardHook = HookFunc(func(e *Event, level Level, message string) {
 		e.Discard()
+	})
+	contextHook = HookFunc(func(e *Event, level Level, message string) {
+		contextData, ok := e.GetCtx().Value(contextKey).(string)
+		if ok {
+			e.Str("context-data", contextData)
+		}
 	})
 )
 
@@ -119,6 +130,29 @@ func TestHook(t *testing.T) {
 		{"Discard", "", func(log Logger) {
 			log = log.Hook(discardHook)
 			log.Log().Msg("test message")
+		}},
+		{"Context/Background", `{"level":"info","message":"test message"}` + "\n", func(log Logger) {
+			log = log.Hook(contextHook)
+			log.Info().Ctx(context.Background()).Msg("test message")
+		}},
+		{"Context/nil", `{"level":"info","message":"test message"}` + "\n", func(log Logger) {
+			// passing `nil` where a context is wanted is against
+			// the rules, but people still do it.
+			log = log.Hook(contextHook)
+			log.Info().Ctx(nil).Msg("test message") // nolint
+		}},
+		{"Context/valid", `{"level":"info","context-data":"12345abcdef","message":"test message"}` + "\n", func(log Logger) {
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, contextKey, "12345abcdef")
+			log = log.Hook(contextHook)
+			log.Info().Ctx(ctx).Msg("test message")
+		}},
+		{"Context/With/valid", `{"level":"info","context-data":"12345abcdef","message":"test message"}` + "\n", func(log Logger) {
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, contextKey, "12345abcdef")
+			log = log.Hook(contextHook)
+			log = log.With().Ctx(ctx).Logger()
+			log.Info().Msg("test message")
 		}},
 		{"None", `{"level":"error"}` + "\n", func(log Logger) {
 			log.Error().Msg("")

--- a/log.go
+++ b/log.go
@@ -82,8 +82,7 @@
 //     log.Warn().Msg("")
 //     // Output: {"level":"warn","severity":"warn"}
 //
-//
-// Caveats
+// # Caveats
 //
 // There is no fields deduplication out-of-the-box.
 // Using the same key multiple times creates new key in final JSON each time.
@@ -99,6 +98,7 @@
 package zerolog
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -218,6 +218,7 @@ type Logger struct {
 	context []byte
 	hooks   []Hook
 	stack   bool
+	ctx     context.Context
 }
 
 // New creates a root logger with given output writer. If the output writer implements
@@ -455,6 +456,7 @@ func (l *Logger) newEvent(level Level, done func(string)) *Event {
 	e := newEvent(l.w, level)
 	e.done = done
 	e.ch = l.hooks
+	e.ctx = l.ctx
 	if level != NoLevel && LevelFieldName != "" {
 		e.Str(LevelFieldName, LevelFieldMarshalFunc(level))
 	}

--- a/log_test.go
+++ b/log_test.go
@@ -2,6 +2,7 @@ package zerolog
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -119,7 +120,8 @@ func TestWith(t *testing.T) {
 		Uint64("uint64", 10).
 		Float32("float32", 11.101).
 		Float64("float64", 12.30303).
-		Time("time", time.Time{})
+		Time("time", time.Time{}).
+		Ctx(context.Background())
 	_, file, line, _ := runtime.Caller(0)
 	caller := fmt.Sprintf("%s:%d", file, line+3)
 	log := ctx.Caller().Logger()
@@ -344,6 +346,7 @@ func TestFields(t *testing.T) {
 		Dur("dur", 1*time.Second).
 		Time("time", time.Time{}).
 		TimeDiff("diff", now, now.Add(-10*time.Second)).
+		Ctx(context.Background()).
 		Msg("")
 	if got, want := decodeIfBinaryToString(out.Bytes()), `{"caller":"`+caller+`","string":"foo","stringer":"127.0.0.1","stringer_nil":null,"bytes":"bar","hex":"12ef","json":{"some":"json"},"cbor":"data:application/cbor;base64,gwGCAgOCBAU=","func":"func_output","error":"some error","bool":true,"int":1,"int8":2,"int16":3,"int32":4,"int64":5,"uint":6,"uint8":7,"uint16":8,"uint32":9,"uint64":10,"IPv4":"192.168.0.100","IPv6":"2001:db8:85a3::8a2e:370:7334","Mac":"00:14:22:01:23:45","Prefix":"192.168.0.100/24","float32":11.1234,"float64":12.321321321,"dur":1000,"time":"0001-01-01T00:00:00Z","diff":10000}`+"\n"; got != want {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
@@ -462,6 +465,7 @@ func TestFieldsDisabled(t *testing.T) {
 		Dur("dur", 1*time.Second).
 		Time("time", time.Time{}).
 		TimeDiff("diff", now, now.Add(-10*time.Second)).
+		Ctx(context.Background()).
 		Msg("")
 	if got, want := decodeIfBinaryToString(out.Bytes()), ""; got != want {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)


### PR DESCRIPTION
Add Logger.{Trace,Debug,Info,Warn,...}Ctx() and similar functions to allow go context to propagate to Hooks.  Add Event.Context() to make the context retrievable by hooks.  Facilitates writing hooks which fetch tracing context from the go context.

---
This PR helps to address #395, #558 and maybe #290.  It is modeled off of the similar interfaces in the new `slog` stdlib package in go 1.21.