### PR TITLE
feat: display error stack when using `.Fields()`

### DIFF
--- a/context.go
+++ b/context.go
@@ -22,7 +22,7 @@ func (c Context) Logger() Logger {
 // Only map[string]interface{} and []interface{} are accepted. []interface{} must
 // alternate string keys and arbitrary values, and extraneous ones are ignored.
 func (c Context) Fields(fields interface{}) Context {
-	c.l.context = appendFields(c.l.context, fields)
+	c.l.context = appendFields(c.l.context, fields, c.l.stack)
 	return c
 }
 

--- a/event.go
+++ b/event.go
@@ -162,7 +162,7 @@ func (e *Event) Fields(fields interface{}) *Event {
 	if e == nil {
 		return e
 	}
-	e.buf = appendFields(e.buf, fields)
+	e.buf = appendFields(e.buf, fields, e.stack)
 	return e
 }
 

--- a/fields.go
+++ b/fields.go
@@ -111,22 +111,6 @@ func appendFieldList(dst []byte, kvList []interface{}, stack bool) []byte {
 					dst = enc.AppendInterface(dst, m)
 				}
 
-				if stack && ErrorStackMarshaler != nil {
-					enc.AppendArrayDelim(dst)
-					dst = enc.AppendKey(dst, ErrorStackFieldName)
-					switch m := ErrorStackMarshaler(err).(type) {
-					case nil:
-					case error:
-						if m != nil && !isNilValue(m) {
-							dst = enc.AppendString(dst, m.Error())
-						}
-					case string:
-						dst = enc.AppendString(dst, m)
-					default:
-						dst = enc.AppendInterface(dst, m)
-					}
-				}
-
 				if i < (len(val) - 1) {
 					enc.AppendArrayDelim(dst)
 				}

--- a/fields.go
+++ b/fields.go
@@ -12,13 +12,13 @@ func isNilValue(i interface{}) bool {
 	return (*[2]uintptr)(unsafe.Pointer(&i))[1] == 0
 }
 
-func appendFields(dst []byte, fields interface{}) []byte {
+func appendFields(dst []byte, fields interface{}, stack bool) []byte {
 	switch fields := fields.(type) {
 	case []interface{}:
 		if n := len(fields); n&0x1 == 1 { // odd number
 			fields = fields[:n-1]
 		}
-		dst = appendFieldList(dst, fields)
+		dst = appendFieldList(dst, fields, stack)
 	case map[string]interface{}:
 		keys := make([]string, 0, len(fields))
 		for key := range fields {
@@ -28,13 +28,13 @@ func appendFields(dst []byte, fields interface{}) []byte {
 		kv := make([]interface{}, 2)
 		for _, key := range keys {
 			kv[0], kv[1] = key, fields[key]
-			dst = appendFieldList(dst, kv)
+			dst = appendFieldList(dst, kv, stack)
 		}
 	}
 	return dst
 }
 
-func appendFieldList(dst []byte, kvList []interface{}) []byte {
+func appendFieldList(dst []byte, kvList []interface{}, stack bool) []byte {
 	for i, n := 0, len(kvList); i < n; i += 2 {
 		key, val := kvList[i], kvList[i+1]
 		if key, ok := key.(string); ok {
@@ -74,6 +74,21 @@ func appendFieldList(dst []byte, kvList []interface{}) []byte {
 			default:
 				dst = enc.AppendInterface(dst, m)
 			}
+
+			if stack && ErrorStackMarshaler != nil {
+				dst = enc.AppendKey(dst, ErrorStackFieldName)
+				switch m := ErrorStackMarshaler(val).(type) {
+				case nil:
+				case error:
+					if m != nil && !isNilValue(m) {
+						dst = enc.AppendString(dst, m.Error())
+					}
+				case string:
+					dst = enc.AppendString(dst, m)
+				default:
+					dst = enc.AppendInterface(dst, m)
+				}
+			}
 		case []error:
 			dst = enc.AppendArrayStart(dst)
 			for i, err := range val {
@@ -94,6 +109,22 @@ func appendFieldList(dst []byte, kvList []interface{}) []byte {
 					dst = enc.AppendString(dst, m)
 				default:
 					dst = enc.AppendInterface(dst, m)
+				}
+
+				if stack && ErrorStackMarshaler != nil {
+					enc.AppendArrayDelim(dst)
+					dst = enc.AppendKey(dst, ErrorStackFieldName)
+					switch m := ErrorStackMarshaler(err).(type) {
+					case nil:
+					case error:
+						if m != nil && !isNilValue(m) {
+							dst = enc.AppendString(dst, m.Error())
+						}
+					case string:
+						dst = enc.AppendString(dst, m)
+					default:
+						dst = enc.AppendInterface(dst, m)
+					}
 				}
 
 				if i < (len(val) - 1) {

--- a/pkgerrors/stacktrace_test.go
+++ b/pkgerrors/stacktrace_test.go
@@ -22,7 +22,7 @@ func TestLogStack(t *testing.T) {
 	log.Log().Stack().Err(err).Msg("")
 
 	got := out.String()
-	want := `\{"stack":\[\{"func":"TestLogStack","line":"22","source":"stacktrace_test.go"\},.*\],"error":"from error: error message"\}\n`
+	want := `\{"stack":\[\{"func":"TestLogStack","line":"21","source":"stacktrace_test.go"\},.*\],"error":"from error: error message"\}\n`
 	if ok, _ := regexp.MatchString(want, got); !ok {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
@@ -38,7 +38,7 @@ func TestLogStackFields(t *testing.T) {
 	log.Log().Stack().Fields([]interface{}{"error", err}).Msg("")
 
 	got := out.String()
-	want := `\{"error":"from error: error message","stack":\[\{"func":"TestLogStackFields","line":"38","source":"stacktrace_test.go"\},.*\]\}\n`
+	want := `\{"error":"from error: error message","stack":\[\{"func":"TestLogStackFields","line":"37","source":"stacktrace_test.go"\},.*\]\}\n`
 	if ok, _ := regexp.MatchString(want, got); !ok {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
@@ -54,7 +54,7 @@ func TestLogStackFromContext(t *testing.T) {
 	log.Log().Err(err).Msg("") // not explicitly calling Stack()
 
 	got := out.String()
-	want := `\{"stack":\[\{"func":"TestLogStackFromContext","line":"37","source":"stacktrace_test.go"\},.*\],"error":"from error: error message"\}\n`
+	want := `\{"stack":\[\{"func":"TestLogStackFromContext","line":"53","source":"stacktrace_test.go"\},.*\],"error":"from error: error message"\}\n`
 	if ok, _ := regexp.MatchString(want, got); !ok {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}

--- a/pkgerrors/stacktrace_test.go
+++ b/pkgerrors/stacktrace_test.go
@@ -22,7 +22,23 @@ func TestLogStack(t *testing.T) {
 	log.Log().Stack().Err(err).Msg("")
 
 	got := out.String()
-	want := `\{"stack":\[\{"func":"TestLogStack","line":"21","source":"stacktrace_test.go"\},.*\],"error":"from error: error message"\}\n`
+	want := `\{"stack":\[\{"func":"TestLogStack","line":"22","source":"stacktrace_test.go"\},.*\],"error":"from error: error message"\}\n`
+	if ok, _ := regexp.MatchString(want, got); !ok {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestLogStackFields(t *testing.T) {
+	zerolog.ErrorStackMarshaler = MarshalStack
+
+	out := &bytes.Buffer{}
+	log := zerolog.New(out)
+
+	err := fmt.Errorf("from error: %w", errors.New("error message"))
+	log.Log().Stack().Fields([]interface{}{"error", err}).Msg("")
+
+	got := out.String()
+	want := `\{"error":"from error: error message","stack":\[\{"func":"TestLogStackFields","line":"38","source":"stacktrace_test.go"\},.*\]\}\n`
 	if ok, _ := regexp.MatchString(want, got); !ok {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}


### PR DESCRIPTION
Display error stack when using `.Fields()`. Right now, even if the `ErrorStackMarshaler` is set, the stack will not be displayed if there is an error in the Fields() values but only when using Err().