### PR TITLE
Disable HTML escaping in InterfaceMarshalFunc

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -1,6 +1,7 @@
 package zerolog
 
 import (
+	"bytes"
 	"encoding/json"
 	"strconv"
 	"sync/atomic"
@@ -81,8 +82,22 @@ var (
 	}
 
 	// InterfaceMarshalFunc allows customization of interface marshaling.
-	// Default: "encoding/json.Marshal"
-	InterfaceMarshalFunc = json.Marshal
+	// Default: "encoding/json.Marshal" with disabled HTML escaping
+	InterfaceMarshalFunc = func(v interface{}) ([]byte, error) {
+		var buf bytes.Buffer
+		encoder := json.NewEncoder(&buf)
+		encoder.SetEscapeHTML(false)
+		err := encoder.Encode(v)
+		if err != nil {
+			return nil, err
+		}
+		b := buf.Bytes()
+		if len(b) > 0 {
+			// Remove trailing \n which is added by Encode.
+			return b[:len(b)-1], nil
+		}
+		return b, nil
+	}
 
 	// TimeFieldFormat defines the time format of the Time field type. If set to
 	// TimeFormatUnix, TimeFormatUnixMs, TimeFormatUnixMicro or TimeFormatUnixNano, the time is formatted as a UNIX

--- a/log_test.go
+++ b/log_test.go
@@ -1013,3 +1013,12 @@ func TestUnmarshalTextLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestHTMLNoEscaping(t *testing.T) {
+	out := &bytes.Buffer{}
+	log := New(out)
+	log.Log().Interface("head", "<test>").Send()
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"head":"<test>"}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}


### PR DESCRIPTION
I do not think logs needs HTML escaping, but it makes it harder to read logs when they include HTML characters.