### PR TITLE
Make LevelWriterAdapter public

### DIFF
--- a/context.go
+++ b/context.go
@@ -57,7 +57,7 @@ func (c Context) Array(key string, arr LogArrayMarshaler) Context {
 
 // Object marshals an object that implement the LogObjectMarshaler interface.
 func (c Context) Object(key string, obj LogObjectMarshaler) Context {
-	e := newEvent(levelWriterAdapter{ioutil.Discard}, 0)
+	e := newEvent(LevelWriterAdapter{ioutil.Discard}, 0)
 	e.Object(key, obj)
 	c.l.context = enc.AppendObjectData(c.l.context, e.buf)
 	putEvent(e)
@@ -66,7 +66,7 @@ func (c Context) Object(key string, obj LogObjectMarshaler) Context {
 
 // EmbedObject marshals and Embeds an object that implement the LogObjectMarshaler interface.
 func (c Context) EmbedObject(obj LogObjectMarshaler) Context {
-	e := newEvent(levelWriterAdapter{ioutil.Discard}, 0)
+	e := newEvent(LevelWriterAdapter{ioutil.Discard}, 0)
 	e.EmbedObject(obj)
 	c.l.context = enc.AppendObjectData(c.l.context, e.buf)
 	putEvent(e)

--- a/event_test.go
+++ b/event_test.go
@@ -28,7 +28,7 @@ func TestEvent_AnErr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			e := newEvent(levelWriterAdapter{&buf}, DebugLevel)
+			e := newEvent(LevelWriterAdapter{&buf}, DebugLevel)
 			e.AnErr("err", tt.err)
 			_ = e.write()
 			if got, want := strings.TrimSpace(buf.String()), tt.want; got != want {
@@ -40,7 +40,7 @@ func TestEvent_AnErr(t *testing.T) {
 
 func TestEvent_ObjectWithNil(t *testing.T) {
 	var buf bytes.Buffer
-	e := newEvent(levelWriterAdapter{&buf}, DebugLevel)
+	e := newEvent(LevelWriterAdapter{&buf}, DebugLevel)
 	_ = e.Object("obj", nil)
 	_ = e.write()
 
@@ -53,7 +53,7 @@ func TestEvent_ObjectWithNil(t *testing.T) {
 
 func TestEvent_EmbedObjectWithNil(t *testing.T) {
 	var buf bytes.Buffer
-	e := newEvent(levelWriterAdapter{&buf}, DebugLevel)
+	e := newEvent(LevelWriterAdapter{&buf}, DebugLevel)
 	_ = e.EmbedObject(nil)
 	_ = e.write()
 

--- a/log.go
+++ b/log.go
@@ -250,7 +250,7 @@ func New(w io.Writer) Logger {
 	}
 	lw, ok := w.(LevelWriter)
 	if !ok {
-		lw = levelWriterAdapter{w}
+		lw = LevelWriterAdapter{w}
 	}
 	return Logger{w: lw, level: TraceLevel}
 }

--- a/writer.go
+++ b/writer.go
@@ -17,11 +17,13 @@ type LevelWriter interface {
 	WriteLevel(level Level, p []byte) (n int, err error)
 }
 
-type levelWriterAdapter struct {
+// LevelWriterAdapter adapts an io.Writer to support the LevelWriter interface.
+type LevelWriterAdapter struct {
 	io.Writer
 }
 
-func (lw levelWriterAdapter) WriteLevel(l Level, p []byte) (n int, err error) {
+// WriteLevel simply writes everything to the adapted writer, ignoring the level.
+func (lw LevelWriterAdapter) WriteLevel(l Level, p []byte) (n int, err error) {
 	return lw.Write(p)
 }
 
@@ -38,7 +40,7 @@ func SyncWriter(w io.Writer) io.Writer {
 	if lw, ok := w.(LevelWriter); ok {
 		return &syncWriter{lw: lw}
 	}
-	return &syncWriter{lw: levelWriterAdapter{w}}
+	return &syncWriter{lw: LevelWriterAdapter{w}}
 }
 
 // Write implements the io.Writer interface.
@@ -96,7 +98,7 @@ func MultiLevelWriter(writers ...io.Writer) LevelWriter {
 		if lw, ok := w.(LevelWriter); ok {
 			lwriters = append(lwriters, lw)
 		} else {
-			lwriters = append(lwriters, levelWriterAdapter{w})
+			lwriters = append(lwriters, LevelWriterAdapter{w})
 		}
 	}
 	return multiLevelWriter{lwriters}


### PR DESCRIPTION
I noticed that I have a copy of this adapter in my own code so maybe it should just be made public. I am using this in combination with FilteredWriter, which logs only at configured level or above.