### PR TITLE
FilteredLevelWriter writes only logs at Level or above

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -154,3 +154,29 @@ func ConsoleTestWriter(t TestingLog) func(w *ConsoleWriter) {
 		w.Out = TestWriter{T: t, Frame: 6}
 	}
 }
+
+// FilteredLevelWriter writes only logs at Level or above to Writer.
+//
+// It should be used only in combination with MultiLevelWriter when you
+// want to write to multiple destinations at different levels. Otherwise
+// you should just set the level on the logger and filter events early.
+// When using MultiLevelWriter then you set the level on the logger to
+// the lowest of the levels you use for writers.
+type FilteredLevelWriter struct {
+	Writer LevelWriter
+	Level  Level
+}
+
+// Write writes to the underlying Writer.
+func (w *FilteredLevelWriter) Write(p []byte) (int, error) {
+	return w.Writer.Write(p)
+}
+
+// WriteLevel calls WriteLevel of the underlying Writer only if the level is equal
+// or above the Level.
+func (w *FilteredLevelWriter) WriteLevel(level Level, p []byte) (int, error) {
+	if level >= w.Level {
+		return w.Writer.WriteLevel(level, p)
+	}
+	return len(p), nil
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -175,3 +175,23 @@ func TestTestWriter(t *testing.T) {
 	}
 
 }
+
+func TestFilteredLevelWriter(t *testing.T) {
+	buf := bytes.Buffer{}
+	writer := FilteredLevelWriter{
+		Writer: LevelWriterAdapter{&buf},
+		Level:  InfoLevel,
+	}
+	_, err := writer.WriteLevel(DebugLevel, []byte("no"))
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = writer.WriteLevel(InfoLevel, []byte("yes"))
+	if err != nil {
+		t.Error(err)
+	}
+	p := buf.Bytes()
+	if want := "yes"; !bytes.Equal([]byte(want), p) {
+		t.Errorf("Expected %q, got %q.", want, p)
+	}
+}


### PR DESCRIPTION
Fixes #150.

This allows one to combine `FilteredLevelWriter`, `LevelWriterAdapter` and `MultiLevelWriter` into any way you want. E.g., have info and above being logged to the console while all levels to a file.