### PR TITLE
Add EmptyFields method to remove all the fileds from logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ _obj
 _test
 tmp
 
+# IDE config files
+.idea
+.vscode
+
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,6 @@ _obj
 _test
 tmp
 
-# IDE config files
-.idea
-.vscode
-
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/context.go
+++ b/context.go
@@ -384,7 +384,7 @@ func (c Context) Any(key string, i interface{}) Context {
 	return c.Interface(key, i)
 }
 
-// EmptyFields removes all the context fields.
+// Reset removes all the context fields.
 func (c Context) Reset() Context {
 	c.l.context = enc.AppendBeginMarker(make([]byte, 0, 500))
 	return c

--- a/context.go
+++ b/context.go
@@ -385,7 +385,7 @@ func (c Context) Any(key string, i interface{}) Context {
 }
 
 // EmptyFields removes all the context fields.
-func (c Context) EmptyFields() Context {
+func (c Context) Reset() Context {
 	c.l.context = enc.AppendBeginMarker(make([]byte, 0, 500))
 	return c
 }

--- a/context.go
+++ b/context.go
@@ -384,6 +384,12 @@ func (c Context) Any(key string, i interface{}) Context {
 	return c.Interface(key, i)
 }
 
+// EmptyFields removes all the context fields.
+func (c Context) EmptyFields() Context {
+	c.l.context = enc.AppendBeginMarker(make([]byte, 0, 500))
+	return c
+}
+
 type callerHook struct {
 	callerSkipFrameCount int
 }

--- a/log_test.go
+++ b/log_test.go
@@ -145,7 +145,7 @@ func TestWith(t *testing.T) {
 	}
 }
 
-func TestWithEmptyFields(t *testing.T) {
+func TestWithReset(t *testing.T) {
 	out := &bytes.Buffer{}
 	ctx := New(out).With().
 		Str("string", "foo").

--- a/log_test.go
+++ b/log_test.go
@@ -145,6 +145,25 @@ func TestWith(t *testing.T) {
 	}
 }
 
+func TestWithEmptyFields(t *testing.T) {
+	out := &bytes.Buffer{}
+	ctx := New(out).With().
+		Str("string", "foo").
+		Stringer("stringer", net.IP{127, 0, 0, 1}).
+		Stringer("stringer_nil", nil).
+		EmptyFields().
+		Bytes("bytes", []byte("bar")).
+		Hex("hex", []byte{0x12, 0xef}).
+		Uint64("uint64", 10).
+		Float64("float64", 12.30303).
+		Ctx(context.Background())
+	log := ctx.Logger()
+	log.Log().Msg("")
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"bytes":"bar","hex":"12ef","uint64":10,"float64":12.30303}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
 func TestFieldsMap(t *testing.T) {
 	out := &bytes.Buffer{}
 	log := New(out)

--- a/log_test.go
+++ b/log_test.go
@@ -151,7 +151,7 @@ func TestWithReset(t *testing.T) {
 		Str("string", "foo").
 		Stringer("stringer", net.IP{127, 0, 0, 1}).
 		Stringer("stringer_nil", nil).
-		EmptyFields().
+		Reset().
 		Bytes("bytes", []byte("bar")).
 		Hex("hex", []byte{0x12, 0xef}).
 		Uint64("uint64", 10).


### PR DESCRIPTION
Hello dear zerolog maintainers! First of all, thanks for the great logging package, which is also the fastest logger available. Hats off to everyone who worked on it.

This feature adds the ability to clear all previously added fields when creating a new logger.

Sometimes, when I pass the logger from one part of my service to another, I want to keep all the logger settings, but remove all the fields. For example, I can use the same field name to identify the context of the logger. If I reuse it, the result will have many fields with the same name, which doesn't look good:
`{"level":"info","context":"internal-logic","context":"db-adapter","context":"db-driver","message":"something"}`

Using this method, I can create a new logger instance like this:
`log.With().EmptyFields().Str("context","db-driver").Logger()`
And later have messages with only one "context" field:
`{"level":"info","context":"db-driver","message":"something"}`