### PR TITLE
Missing trace output on syslog level writer

### DIFF
--- a/syslog.go
+++ b/syslog.go
@@ -34,8 +34,8 @@ func SyslogLevelWriter(w SyslogWriter) LevelWriter {
 }
 
 // SyslogCEEWriter wraps a SyslogWriter with a SyslogLevelWriter that adds a
-// MITRE CEE prefix for JSON syslog entries, compatible with rsyslog 
-// and syslog-ng JSON logging support. 
+// MITRE CEE prefix for JSON syslog entries, compatible with rsyslog
+// and syslog-ng JSON logging support.
 // See https://www.rsyslog.com/json-elasticsearch/
 func SyslogCEEWriter(w SyslogWriter) LevelWriter {
 	return syslogWriter{w, ceePrefix}
@@ -57,6 +57,7 @@ func (sw syslogWriter) Write(p []byte) (n int, err error) {
 func (sw syslogWriter) WriteLevel(level Level, p []byte) (n int, err error) {
 	switch level {
 	case TraceLevel:
+		err = sw.w.Debug(sw.prefix + string(p))
 	case DebugLevel:
 		err = sw.w.Debug(sw.prefix + string(p))
 	case InfoLevel:

--- a/syslog_test.go
+++ b/syslog_test.go
@@ -60,6 +60,7 @@ func TestSyslogWriter(t *testing.T) {
 	log.Error().Msg("error")
 	log.Log().Msg("nolevel")
 	want := []syslogEvent{
+		{"Trace", `{"level":"trace","message":"trace"}` + "\n"},
 		{"Debug", `{"level":"debug","message":"debug"}` + "\n"},
 		{"Info", `{"level":"info","message":"info"}` + "\n"},
 		{"Warning", `{"level":"warn","message":"warn"}` + "\n"},


### PR DESCRIPTION
Just like the title.  When i want to use the syslog level writer + syslog output send messages.  All others , e.g.  "debug", "info" .. worked well. But the trace func , i got empty from syslog service( using journald )  

I found there has a missing in syslog.go  WriteLevel .

I also created a issues https://github.com/rs/zerolog/issues/578 , 