### PR TITLE
Use `sync.Pool` and `bytes.Buffer` for `Logger.With` perf improvement

### DIFF
--- a/log.go
+++ b/log.go
@@ -114,6 +114,7 @@
 package zerolog
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -122,7 +123,14 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 )
+
+var contextBufPool = &sync.Pool{
+	New: func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, 500))
+	},
+}
 
 // Level defines log levels.
 type Level int8
@@ -278,15 +286,18 @@ func (l Logger) Output(w io.Writer) Logger {
 
 // With creates a child logger with the field added to its context.
 func (l Logger) With() Context {
-	context := l.context
-	l.context = make([]byte, 0, 500)
-	if context != nil {
-		l.context = append(l.context, context...)
+	buf := contextBufPool.Get().(*bytes.Buffer)
+	ctx := l.context
+	if ctx != nil {
+		buf.Write(ctx)
 	} else {
 		// This is needed for AppendKey to not check len of input
 		// thus making it inlinable
-		l.context = enc.AppendBeginMarker(l.context)
+		buf.Write(enc.AppendBeginMarker(buf.Bytes()))
 	}
+	l.context = buf.Bytes()
+	buf.Reset()
+	contextBufPool.Put(buf)
 	return Context{l}
 }
 
@@ -299,7 +310,9 @@ func (l *Logger) UpdateContext(update func(c Context) Context) {
 		return
 	}
 	if cap(l.context) == 0 {
-		l.context = make([]byte, 0, 500)
+		buf := contextBufPool.Get().(*bytes.Buffer)
+		l.context = buf.Bytes()
+		contextBufPool.Put(buf)
 	}
 	if len(l.context) == 0 {
 		l.context = enc.AppendBeginMarker(l.context)


### PR DESCRIPTION
There are currently a lot of allocations in the `Logger.With` due to direct `make` calls. This PR replaces it by using `sync.Pool` and `bytes.Buffer`.