### PR TITLE
Add FormatPrepare to ConsoleWriter

### DIFF
--- a/console.go
+++ b/console.go
@@ -76,6 +76,8 @@ type ConsoleWriter struct {
 	FormatErrFieldValue Formatter
 
 	FormatExtra func(map[string]interface{}, *bytes.Buffer) error
+
+	FormatPrepare func(map[string]interface{}) error
 }
 
 // NewConsoleWriter creates and initializes a new ConsoleWriter.
@@ -122,6 +124,13 @@ func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 	err = d.Decode(&evt)
 	if err != nil {
 		return n, fmt.Errorf("cannot decode event: %s", err)
+	}
+
+	if w.FormatPrepare != nil {
+		err = w.FormatPrepare(evt)
+		if err != nil {
+			return n, err
+		}
 	}
 
 	for _, p := range w.PartsOrder {

--- a/console_test.go
+++ b/console_test.go
@@ -418,6 +418,29 @@ func TestConsoleWriterConfiguration(t *testing.T) {
 		}
 	})
 
+	t.Run("Sets FormatPrepare", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		w := zerolog.ConsoleWriter{
+			Out: buf, NoColor: true, PartsOrder: []string{"level", "message"},
+			FormatPrepare: func(evt map[string]interface{}) error {
+				evt["message"] = fmt.Sprintf("msg=%s", evt["message"])
+				return nil
+			},
+		}
+
+		evt := `{"level": "info", "message": "Foobar"}`
+		_, err := w.Write([]byte(evt))
+		if err != nil {
+			t.Errorf("Unexpected error when writing output: %s", err)
+		}
+
+		expectedOutput := "INF msg=Foobar\n"
+		actualOutput := buf.String()
+		if actualOutput != expectedOutput {
+			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
+		}
+	})
+
 	t.Run("Uses local time for console writer without time zone", func(t *testing.T) {
 		// Regression test for issue #483 (check there for more details)
 


### PR DESCRIPTION
I realized that most of the recent additions like `PartsExclude` and `FieldsExclude` could be done just be some preprocessing before formatting starts.

In my particular case, I realized that I cannot use `FormatMessage` because it has access only to the message and not other fields: but I want to make it bold only if the level is info or above.

So `FormatPrepare` allows all such changes: removing fields, adding fields, changing fields.