### PR TITLE
Do not colorize if not necessary

### DIFF
--- a/console.go
+++ b/console.go
@@ -319,10 +319,10 @@ func needsQuote(s string) bool {
 	return false
 }
 
-// colorize returns the string s wrapped in ANSI code c, unless disabled is true.
+// colorize returns the string s wrapped in ANSI code c, unless disabled is true or c is 0.
 func colorize(s interface{}, c int, disabled bool) string {
 	e := os.Getenv("NO_COLOR")
-	if e != "" {
+	if e != "" || c == 0 {
 		disabled = true
 	}
 


### PR DESCRIPTION
Small cosmetic improvement. If provided color is `0`, do not colorize it.

(For debug level, default level color is 0 now, so nothing really has to be done.)