### PR TITLE
Use map for formatted levels

### DIFF
--- a/console.go
+++ b/console.go
@@ -387,27 +387,16 @@ func consoleDefaultFormatLevel(noColor bool) Formatter {
 	return func(i interface{}) string {
 		var l string
 		if ll, ok := i.(string); ok {
-			switch ll {
-			case LevelTraceValue:
-				l = colorize("TRC", LevelColors["TRC"], noColor)
-			case LevelDebugValue:
-				l = colorize("DBG", LevelColors["DBG"], noColor)
-			case LevelInfoValue:
-				l = colorize("INF", LevelColors["INF"], noColor)
-			case LevelWarnValue:
-				l = colorize("WRN", LevelColors["WRN"], noColor)
-			case LevelErrorValue:
-				l = colorize("ERR", LevelColors["ERR"], noColor)
-			case LevelFatalValue:
-				l = colorize("FTL", LevelColors["FTL"], noColor)
-			case LevelPanicValue:
-				l = colorize("PNC", LevelColors["PNC"], noColor)
-			default:
+			level, _ := ParseLevel(ll)
+			fl, ok := FormattedLevels[level]
+			if ok {
+				l = colorize(fl, LevelColors[level], noColor)
+			} else {
 				l = strings.ToUpper(ll)[0:3]
 			}
 		} else {
 			if i == nil {
-				l = colorize("???", colorBold, noColor)
+				l = "???"
 			} else {
 				l = strings.ToUpper(fmt.Sprintf("%s", i))[0:3]
 			}

--- a/globals.go
+++ b/globals.go
@@ -111,14 +111,26 @@ var (
 
 	// LevelColors are used by ConsoleWriter's consoleDefaultFormatLevel to color
 	// log levels.
-	LevelColors = map[string]int{
-		"TRC": colorBlue,
-		"DBG": 0,
-		"INF": colorGreen,
-		"WRN": colorYellow,
-		"ERR": colorRed,
-		"FTL": colorRed,
-		"PNC": colorRed,
+	LevelColors = map[Level]int{
+		TraceLevel: colorBlue,
+		DebugLevel: 0,
+		InfoLevel:  colorGreen,
+		WarnLevel:  colorYellow,
+		ErrorLevel: colorRed,
+		FatalLevel: colorRed,
+		PanicLevel: colorRed,
+	}
+
+	// FormattedLevels are used by ConsoleWriter's consoleDefaultFormatLevel
+	// for a short level name.
+	FormattedLevels = map[Level]string{
+		TraceLevel: "TRC",
+		DebugLevel: "DBG",
+		InfoLevel:  "INF",
+		WarnLevel:  "WRN",
+		ErrorLevel: "ERR",
+		FatalLevel: "FTL",
+		PanicLevel: "PNC",
 	}
 )
 


### PR DESCRIPTION
Sorry, I realized there could be few more improvements in code here:
* Use map for formatted levels. So only one place to parse levels.
* No bold for no level case as well.