### PR TITLE
Add additional hlog logging handlers

### DIFF
--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -271,6 +271,23 @@ func EtagHandler(fieldKey string) func(next http.Handler) http.Handler {
 	}
 }
 
+func ResponseHeaderHandler(fieldKey, headerName string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				value := w.Header().Get(headerName)
+				if value != "" {
+					log := zerolog.Ctx(r.Context())
+					log.UpdateContext(func(c zerolog.Context) zerolog.Context {
+						return c.Str(fieldKey, value)
+					})
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // AccessHandler returns a handler that call f after each request.
 func AccessHandler(f func(r *http.Request, status, size int, duration time.Duration)) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {

--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -294,8 +294,10 @@ func AccessHandler(f func(r *http.Request, status, size int, duration time.Durat
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			lw := mutil.WrapWriter(w)
+			defer func() {
+				f(r, lw.Status(), lw.BytesWritten(), time.Since(start))
+			}()
 			next.ServeHTTP(lw, r)
-			f(r, lw.Status(), lw.BytesWritten(), time.Since(start))
 		})
 	}
 }

--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -4,6 +4,7 @@ package hlog
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/rs/xid"
@@ -129,6 +130,21 @@ func ProtoHandler(fieldKey string) func(next http.Handler) http.Handler {
 			log := zerolog.Ctx(r.Context())
 			log.UpdateContext(func(c zerolog.Context) zerolog.Context {
 				return c.Str(fieldKey, r.Proto)
+			})
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// HTTPVersionHandler is similar to ProtoHandler, but it does not store the "HTTP/"
+// prefix in the protocol name.
+func HTTPVersionHandler(fieldKey string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			proto := strings.TrimPrefix(r.Proto, "HTTP/")
+			log := zerolog.Ctx(r.Context())
+			log.UpdateContext(func(c zerolog.Context) zerolog.Context {
+				return c.Str(fieldKey, proto)
 			})
 			next.ServeHTTP(w, r)
 		})

--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -251,6 +251,26 @@ func CustomHeaderHandler(fieldKey, header string) func(next http.Handler) http.H
 	}
 }
 
+// EtagHandler adds Etag header from response's header as a field to
+// the context's logger using fieldKey as field key.
+func EtagHandler(fieldKey string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				etag := w.Header().Get("Etag")
+				if etag != "" {
+					etag = strings.ReplaceAll(etag, `"`, "")
+					log := zerolog.Ctx(r.Context())
+					log.UpdateContext(func(c zerolog.Context) zerolog.Context {
+						return c.Str(fieldKey, etag)
+					})
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // AccessHandler returns a handler that call f after each request.
 func AccessHandler(f func(r *http.Request, status, size int, duration time.Duration)) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -122,6 +122,38 @@ func TestRemoteAddrHandlerIPv6(t *testing.T) {
 	}
 }
 
+func TestRemoteIPHandler(t *testing.T) {
+	out := &bytes.Buffer{}
+	r := &http.Request{
+		RemoteAddr: "1.2.3.4:1234",
+	}
+	h := RemoteIPHandler("ip")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l := FromRequest(r)
+		l.Log().Msg("")
+	}))
+	h = NewHandler(zerolog.New(out))(h)
+	h.ServeHTTP(nil, r)
+	if want, got := `{"ip":"1.2.3.4"}`+"\n", decodeIfBinary(out); want != got {
+		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
+	}
+}
+
+func TestRemoteIPHandlerIPv6(t *testing.T) {
+	out := &bytes.Buffer{}
+	r := &http.Request{
+		RemoteAddr: "[2001:db8:a0b:12f0::1]:1234",
+	}
+	h := RemoteIPHandler("ip")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l := FromRequest(r)
+		l.Log().Msg("")
+	}))
+	h = NewHandler(zerolog.New(out))(h)
+	h.ServeHTTP(nil, r)
+	if want, got := `{"ip":"2001:db8:a0b:12f0::1"}`+"\n", decodeIfBinary(out); want != got {
+		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
+	}
+}
+
 func TestUserAgentHandler(t *testing.T) {
 	out := &bytes.Buffer{}
 	r := &http.Request{

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -217,6 +217,22 @@ func TestProtoHandler(t *testing.T) {
 	}
 }
 
+func TestHTTPVersionHandler(t *testing.T) {
+	out := &bytes.Buffer{}
+	r := &http.Request{
+		Proto: "HTTP/1.1",
+	}
+	h := HTTPVersionHandler("proto")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l := FromRequest(r)
+		l.Log().Msg("")
+	}))
+	h = NewHandler(zerolog.New(out))(h)
+	h.ServeHTTP(nil, r)
+	if want, got := `{"proto":"1.1"}`+"\n", decodeIfBinary(out); want != got {
+		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
+	}
+}
+
 func TestCombinedHandlers(t *testing.T) {
 	out := &bytes.Buffer{}
 	r := &http.Request{

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -408,3 +408,28 @@ func TestHostHandlerWithoutPort(t *testing.T) {
 		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
 	}
 }
+
+func TestGetHost(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"example.com:8080", "example.com"},
+		{"example.com", "example.com"},
+		{"invalid", "invalid"},
+		{"192.168.0.1:8080", "192.168.0.1"},
+		{"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:8080", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
+		{"こんにちは.com:8080", "こんにちは.com"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			result := getHost(tt.input)
+			if tt.expected != result {
+				t.Errorf("Invalid log output, got: %s, want: %s", result, tt.expected)
+			}
+		})
+	}
+}

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -343,8 +343,22 @@ func TestCtxWithID(t *testing.T) {
 
 func TestHostHandler(t *testing.T) {
 	out := &bytes.Buffer{}
-	r := &http.Request{Host: "example.com"}
+	r := &http.Request{Host: "example.com:8080"}
 	h := HostHandler("host")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l := FromRequest(r)
+		l.Log().Msg("")
+	}))
+	h = NewHandler(zerolog.New(out))(h)
+	h.ServeHTTP(nil, r)
+	if want, got := `{"host":"example.com:8080"}`+"\n", decodeIfBinary(out); want != got {
+		t.Errorf("Invalid log output, got: %s, want: %s", got, want)
+	}
+}
+
+func TestHostHandlerWithoutPort(t *testing.T) {
+	out := &bytes.Buffer{}
+	r := &http.Request{Host: "example.com:8080"}
+	h := HostHandler("host", true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		l := FromRequest(r)
 		l.Log().Msg("")
 	}))


### PR DESCRIPTION
* `HTTPVersionHandler`: Similar to `ProtoHandler`, just without `HTTP/` prefix. In practice, there is always `HTTP/` prefix, so we can drop that (if it exists, which it does) to have more compact logs.
* `RemoteAddrHandlerWithoutPort`: Similar to `RemoteAddrHandler`, but do you really care about a remote port? Remote port makes it hard to aggregate logs based on remote IP.
* `HostHandlerWithoutPort`: Is similar, generally you do not care on which local port you run stuff.
* `EtagHandler`: Logs response header, `Etag`, can help with debugging which version of content user got.
* `ResponseHeaderHandler`: Similar to `CustomHeaderHandler`, but for response headers. If you do canonical log lines, you probably have middleware which logs it after everything is handled, so this handler should be earlier in the middleware stack.