### PR TITLE
hlog: Don't write StatusOK header for websockets

### DIFF
--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -210,7 +210,8 @@ func AccessHandler(f func(r *http.Request, status, size int, duration time.Durat
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
-			lw := mutil.WrapWriter(w)
+			isWs := r.Header.Get("upgrade") == "websocket"
+			lw := mutil.WrapWriter(w, isWs)
 			next.ServeHTTP(lw, r)
 			f(r, lw.Status(), lw.BytesWritten(), time.Since(start))
 		})


### PR DESCRIPTION
When logging requests and the request is a websocket and the websocket is not properly closed (e.g. the client reloads the page, disconnecting the socket), then hlog tries to write `http.StatusOK` via `WriteHeader()` to the hijacked connection which fails as described here

https://stackoverflow.com/questions/32657603/why-do-i-get-the-error-message-http-response-write-on-hijacked-connection

This PR addresses this problem by passing a flag into the `WrapWriter()` func to indicate whether the request is a Websocket. In this case, the `WriteHeader()` is suppressed.