### PR TITLE
Add base64 helper methods

### DIFF
--- a/array.go
+++ b/array.go
@@ -1,6 +1,7 @@
 package zerolog
 
 import (
+	"encoding/base64"
 	"net"
 	"sync"
 	"time"
@@ -82,6 +83,19 @@ func (a *Array) Bytes(val []byte) *Array {
 // Hex appends the val as a hex string to the array.
 func (a *Array) Hex(val []byte) *Array {
 	a.buf = enc.AppendHex(enc.AppendArrayDelim(a.buf), val)
+	return a
+}
+
+// Base64 appends the val as a standard padded base64 string to the array.
+func (a *Array) Base64(val []byte) *Array {
+	a.buf = enc.AppendBase64(base64.StdEncoding, enc.AppendArrayDelim(a.buf), val)
+	return a
+}
+
+// Base64Custom appends the val as a base64 string to the array.
+// The specific form of base64 can be specified with the first parameter.
+func (a *Array) Base64Custom(b64 *base64.Encoding, val []byte) *Array {
+	a.buf = enc.AppendBase64(b64, enc.AppendArrayDelim(a.buf), val)
 	return a
 }
 

--- a/array_test.go
+++ b/array_test.go
@@ -1,6 +1,7 @@
 package zerolog
 
 import (
+	"encoding/base64"
 	"net"
 	"testing"
 	"time"
@@ -24,6 +25,8 @@ func TestArray(t *testing.T) {
 		Str("a").
 		Bytes([]byte("b")).
 		Hex([]byte{0x1f}).
+		Base64([]byte{0x12, 0xef, 0x29, 0x30, 0xff}).
+		Base64Custom(base64.RawURLEncoding, []byte{0xcc, 0xbb, 0xaa, 0xff}).
 		RawJSON([]byte(`{"some":"json"}`)).
 		Time(time.Time{}).
 		IPAddr(net.IP{192, 168, 0, 10}).
@@ -32,7 +35,7 @@ func TestArray(t *testing.T) {
 			Str("bar", "baz").
 			Int("n", 1),
 		)
-	want := `[true,1,2,3,4,5,6,7,8,9,10,11.98122,12.987654321,"a","b","1f",{"some":"json"},"0001-01-01T00:00:00Z","192.168.0.10",0,{"bar":"baz","n":1}]`
+	want := `[true,1,2,3,4,5,6,7,8,9,10,11.98122,12.987654321,"a","b","1f","Eu8pMP8=","zLuq_w",{"some":"json"},"0001-01-01T00:00:00Z","192.168.0.10",0,{"bar":"baz","n":1}]`
 	if got := decodeObjectToStr(a.write([]byte{})); got != want {
 		t.Errorf("Array.write()\ngot:  %s\nwant: %s", got, want)
 	}

--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package zerolog
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -105,6 +106,19 @@ func (c Context) Bytes(key string, val []byte) Context {
 // Hex adds the field key with val as a hex string to the logger context.
 func (c Context) Hex(key string, val []byte) Context {
 	c.l.context = enc.AppendHex(enc.AppendKey(c.l.context, key), val)
+	return c
+}
+
+// Base64 adds the field key with val as a standard padded base64 string to the logger context.
+func (c Context) Base64(key string, val []byte) Context {
+	c.l.context = enc.AppendBase64(base64.StdEncoding, enc.AppendKey(c.l.context, key), val)
+	return c
+}
+
+// Base64Custom adds the field key with val as a base64 string to the logger context.
+// The specific form of base64 can be specified with the first parameter.
+func (c Context) Base64Custom(b64 *base64.Encoding, key string, val []byte) Context {
+	c.l.context = enc.AppendBase64(b64, enc.AppendKey(c.l.context, key), val)
 	return c
 }
 

--- a/event.go
+++ b/event.go
@@ -2,6 +2,7 @@ package zerolog
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"os"
@@ -305,6 +306,25 @@ func (e *Event) Hex(key string, val []byte) *Event {
 		return e
 	}
 	e.buf = enc.AppendHex(enc.AppendKey(e.buf, key), val)
+	return e
+}
+
+// Base64 adds the field key with val as a standard padded base64 string to the *Event context.
+func (e *Event) Base64(key string, val []byte) *Event {
+	if e == nil {
+		return e
+	}
+	e.buf = enc.AppendBase64(base64.StdEncoding, enc.AppendKey(e.buf, key), val)
+	return e
+}
+
+// Base64Custom adds the field key with val as a base64 string to the *Event context.
+// The specific form of base64 can be specified with the first parameter.
+func (e *Event) Base64Custom(b64 *base64.Encoding, key string, val []byte) *Event {
+	if e == nil {
+		return e
+	}
+	e.buf = enc.AppendBase64(b64, enc.AppendKey(e.buf, key), val)
 	return e
 }
 

--- a/internal/json/bytes.go
+++ b/internal/json/bytes.go
@@ -1,6 +1,9 @@
 package json
 
-import "unicode/utf8"
+import (
+	"encoding/base64"
+	"unicode/utf8"
+)
 
 // AppendBytes is a mirror of appendString with []byte arg
 func (Encoder) AppendBytes(dst, s []byte) []byte {
@@ -25,6 +28,20 @@ func (Encoder) AppendHex(dst, s []byte) []byte {
 	for _, v := range s {
 		dst = append(dst, hex[v>>4], hex[v&0x0f])
 	}
+	return append(dst, '"')
+}
+
+// AppendBase64 encodes the input bytes to a base64 string and appends
+// the encoded string to the input byte slice.
+func (Encoder) AppendBase64(e *base64.Encoding, dst, s []byte) []byte {
+	dst = append(dst, '"')
+	start := len(dst)
+	targetLen := start + e.EncodedLen(len(s))
+	for cap(dst) < targetLen {
+		dst = append(dst[:cap(dst)], 0)
+	}
+	dst = dst[:targetLen]
+	e.Encode(dst[start:], s)
 	return append(dst, '"')
 }
 

--- a/internal/json/bytes_test.go
+++ b/internal/json/bytes_test.go
@@ -1,6 +1,8 @@
 package json
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"testing"
 	"unicode"
 )
@@ -21,6 +23,30 @@ func TestAppendHex(t *testing.T) {
 		b := enc.AppendHex([]byte{}, []byte{tt.in})
 		if got, want := string(b), tt.out; got != want {
 			t.Errorf("appendHex(%x) = %s, want %s", tt.in, got, want)
+		}
+	}
+}
+
+var base64Encodings = []struct {
+	name string
+	enc  *base64.Encoding
+}{
+	{"base64.StdEncoding", base64.StdEncoding},
+	{"base64.RawStdEncoding", base64.RawStdEncoding},
+	{"base64.URLEncoding", base64.URLEncoding},
+	{"base64.RawURLEncoding", base64.RawURLEncoding},
+}
+
+func TestAppendBase64(t *testing.T) {
+	random := make([]byte, 19)
+	_, _ = rand.Read(random)
+	tests := [][]byte{{}, {'\x00'}, {'\xff'}, random}
+	for _, input := range tests {
+		for _, tt := range base64Encodings {
+			b := enc.AppendBase64(tt.enc, []byte{}, input)
+			if got, want := string(b), "\""+tt.enc.EncodeToString(input)+"\""; got != want {
+				t.Errorf("appendBase64(%s, %x) = %s, want %s", tt.name, input, got, want)
+			}
 		}
 	}
 }

--- a/log_test.go
+++ b/log_test.go
@@ -3,6 +3,7 @@ package zerolog
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net"
@@ -104,6 +105,8 @@ func TestWith(t *testing.T) {
 		Stringer("stringer_nil", nil).
 		Bytes("bytes", []byte("bar")).
 		Hex("hex", []byte{0x12, 0xef}).
+		Base64("base64", []byte{0x12, 0xef, 0x29, 0x30, 0xff}).
+		Base64Custom(base64.RawURLEncoding, "base64url", []byte{0xcc, 0xbb, 0xaa, 0xff}).
 		RawJSON("json", []byte(`{"some":"json"}`)).
 		AnErr("some_err", nil).
 		Err(errors.New("some error")).
@@ -126,7 +129,7 @@ func TestWith(t *testing.T) {
 	caller := fmt.Sprintf("%s:%d", file, line+3)
 	log := ctx.Caller().Logger()
 	log.Log().Msg("")
-	if got, want := decodeIfBinaryToString(out.Bytes()), `{"string":"foo","stringer":"127.0.0.1","stringer_nil":null,"bytes":"bar","hex":"12ef","json":{"some":"json"},"error":"some error","bool":true,"int":1,"int8":2,"int16":3,"int32":4,"int64":5,"uint":6,"uint8":7,"uint16":8,"uint32":9,"uint64":10,"float32":11.101,"float64":12.30303,"time":"0001-01-01T00:00:00Z","caller":"`+caller+`"}`+"\n"; got != want {
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"string":"foo","stringer":"127.0.0.1","stringer_nil":null,"bytes":"bar","hex":"12ef","base64":"Eu8pMP8=","base64url":"zLuq_w","json":{"some":"json"},"error":"some error","bool":true,"int":1,"int8":2,"int16":3,"int32":4,"int64":5,"uint":6,"uint8":7,"uint16":8,"uint32":9,"uint64":10,"float32":11.101,"float64":12.30303,"time":"0001-01-01T00:00:00Z","caller":"`+caller+`"}`+"\n"; got != want {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
 
@@ -140,7 +143,7 @@ func TestWith(t *testing.T) {
 	}()
 	// The above line is a little contrived, but the line above should be the line due
 	// to the extra frame skip.
-	if got, want := decodeIfBinaryToString(out.Bytes()), `{"string":"foo","stringer":"127.0.0.1","stringer_nil":null,"bytes":"bar","hex":"12ef","json":{"some":"json"},"error":"some error","bool":true,"int":1,"int8":2,"int16":3,"int32":4,"int64":5,"uint":6,"uint8":7,"uint16":8,"uint32":9,"uint64":10,"float32":11.101,"float64":12.30303,"time":"0001-01-01T00:00:00Z","caller":"`+caller+`"}`+"\n"; got != want {
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"string":"foo","stringer":"127.0.0.1","stringer_nil":null,"bytes":"bar","hex":"12ef","base64":"Eu8pMP8=","base64url":"zLuq_w","json":{"some":"json"},"error":"some error","bool":true,"int":1,"int8":2,"int16":3,"int32":4,"int64":5,"uint":6,"uint8":7,"uint16":8,"uint32":9,"uint64":10,"float32":11.101,"float64":12.30303,"time":"0001-01-01T00:00:00Z","caller":"`+caller+`"}`+"\n"; got != want {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
 }
@@ -321,6 +324,8 @@ func TestFields(t *testing.T) {
 		Stringer("stringer_nil", nil).
 		Bytes("bytes", []byte("bar")).
 		Hex("hex", []byte{0x12, 0xef}).
+		Base64("base64", []byte{0x12, 0xef, 0x29, 0x30, 0xff}).
+		Base64Custom(base64.RawURLEncoding, "base64url", []byte{0xcc, 0xbb, 0xaa, 0xff}).
 		RawJSON("json", []byte(`{"some":"json"}`)).
 		RawCBOR("cbor", []byte{0x83, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05}).
 		Func(func(e *Event) { e.Str("func", "func_output") }).
@@ -348,7 +353,7 @@ func TestFields(t *testing.T) {
 		TimeDiff("diff", now, now.Add(-10*time.Second)).
 		Ctx(context.Background()).
 		Msg("")
-	if got, want := decodeIfBinaryToString(out.Bytes()), `{"caller":"`+caller+`","string":"foo","stringer":"127.0.0.1","stringer_nil":null,"bytes":"bar","hex":"12ef","json":{"some":"json"},"cbor":"data:application/cbor;base64,gwGCAgOCBAU=","func":"func_output","error":"some error","bool":true,"int":1,"int8":2,"int16":3,"int32":4,"int64":5,"uint":6,"uint8":7,"uint16":8,"uint32":9,"uint64":10,"IPv4":"192.168.0.100","IPv6":"2001:db8:85a3::8a2e:370:7334","Mac":"00:14:22:01:23:45","Prefix":"192.168.0.100/24","float32":11.1234,"float64":12.321321321,"dur":1000,"time":"0001-01-01T00:00:00Z","diff":10000}`+"\n"; got != want {
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"caller":"`+caller+`","string":"foo","stringer":"127.0.0.1","stringer_nil":null,"bytes":"bar","hex":"12ef","base64":"Eu8pMP8=","base64url":"zLuq_w","json":{"some":"json"},"cbor":"data:application/cbor;base64,gwGCAgOCBAU=","func":"func_output","error":"some error","bool":true,"int":1,"int8":2,"int16":3,"int32":4,"int64":5,"uint":6,"uint8":7,"uint16":8,"uint32":9,"uint64":10,"IPv4":"192.168.0.100","IPv6":"2001:db8:85a3::8a2e:370:7334","Mac":"00:14:22:01:23:45","Prefix":"192.168.0.100/24","float32":11.1234,"float64":12.321321321,"dur":1000,"time":"0001-01-01T00:00:00Z","diff":10000}`+"\n"; got != want {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
 }
@@ -446,6 +451,8 @@ func TestFieldsDisabled(t *testing.T) {
 		Stringer("stringer", net.IP{127, 0, 0, 1}).
 		Bytes("bytes", []byte("bar")).
 		Hex("hex", []byte{0x12, 0xef}).
+		Base64("base64", []byte{0x12, 0xef, 0x29, 0x30, 0xff}).
+		Base64Custom(base64.RawURLEncoding, "base64url", []byte{0xcc, 0xbb, 0xaa, 0xff}).
 		AnErr("some_err", nil).
 		Err(errors.New("some error")).
 		Func(func(e *Event) { e.Str("func", "func_output") }).


### PR DESCRIPTION
I often find myself wanting to output bytes as base64 instead of hex because base64 is more compact, and the `base64` cli command is easier to use than `xxd`. Having to write `.Str("foo", base64.StdEncoding.EncodeToString(data))` isn't very nice though and it's not as efficient as encoding directly into the buffer.

This PR adds `.Base64` and `.Base64Custom` helper methods. The former just takes bytes and appends with standard padded base64, while the latter additionally takes a `base64.Encoding` instance to allow all the other kinds (urlsafe and/or unpadded base64). I'm not completely sure if the Custom method is a good idea, so I can change that if needed. It might make sense to have an url-safe method instead, or just not have any other options than standard.