### PR TITLE
Add Logger.Enabled method

### DIFF
--- a/log.go
+++ b/log.go
@@ -507,3 +507,14 @@ func (l *Logger) should(lvl Level) bool {
 	}
 	return true
 }
+
+// Enabled returns true if the logger is not disabled.
+func (l *Logger) Enabled() bool {
+	if l.w == nil {
+		return false
+	}
+	if l.level == Disabled || GlobalLevel() == Disabled {
+		return false
+	}
+	return true
+}

--- a/log_test.go
+++ b/log_test.go
@@ -498,6 +498,9 @@ func TestLevel(t *testing.T) {
 		if got, want := decodeIfBinaryToString(out.Bytes()), ""; got != want {
 			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 		}
+		if log.Enabled() {
+			t.Errorf("expect log to be disabled")
+		}
 	})
 
 	t.Run("NoLevel/Disabled", func(t *testing.T) {


### PR DESCRIPTION
This works with Nop and zero Logger. It allows one to skip some initialization if logger is disabled (e.g., skip installing hlog middleware).