### PR TITLE
sampling: Support message-level sampling

### DIFF
--- a/event.go
+++ b/event.go
@@ -29,6 +29,7 @@ type Event struct {
 	ch        []Hook          // hooks from context
 	skipFrame int             // The number of additional frames to skip when printing the caller.
 	ctx       context.Context // Optional Go context for event
+	sampler   MessageSampler  // optional: if set, used to sample messages
 }
 
 func putEvent(e *Event) {
@@ -142,6 +143,11 @@ func (e *Event) msg(msg string) {
 	for _, hook := range e.ch {
 		hook.Run(e, e.level, msg)
 	}
+
+	if e.sampler != nil && !e.sampler.SampleMessage(e.level, msg) {
+		return
+	}
+
 	if msg != "" {
 		e.buf = enc.AppendString(enc.AppendKey(e.buf, MessageFieldName), msg)
 	}

--- a/event.go
+++ b/event.go
@@ -21,15 +21,15 @@ var eventPool = &sync.Pool{
 // Event represents a log event. It is instanced by one of the level method of
 // Logger and finalized by the Msg or Msgf method.
 type Event struct {
-	buf       []byte
-	w         LevelWriter
-	level     Level
-	done      func(msg string)
-	stack     bool            // enable error stack trace
-	ch        []Hook          // hooks from context
-	skipFrame int             // The number of additional frames to skip when printing the caller.
-	ctx       context.Context // Optional Go context for event
-	sampler   MessageSampler  // optional: if set, used to sample messages
+	buf        []byte
+	w          LevelWriter
+	level      Level
+	done       func(msg string)
+	stack      bool            // enable error stack trace
+	ch         []Hook          // hooks from context
+	skipFrame  int             // The number of additional frames to skip when printing the caller.
+	ctx        context.Context // Optional Go context for event
+	msgSampler MessageSampler  // optional: if set, used to sample messages
 }
 
 func putEvent(e *Event) {
@@ -144,7 +144,7 @@ func (e *Event) msg(msg string) {
 		hook.Run(e, e.level, msg)
 	}
 
-	if e.sampler != nil && !e.sampler.SampleMessage(e.level, msg) {
+	if e.msgSampler != nil && !e.msgSampler.SampleMessage(e.level, msg) {
 		return
 	}
 

--- a/log_test.go
+++ b/log_test.go
@@ -585,12 +585,6 @@ type messageAllowlistSampler struct {
 	Allow []string
 }
 
-var _ MessageSampler = (*messageAllowlistSampler)(nil)
-
-func (ms *messageAllowlistSampler) Sample(Level) bool {
-	return true
-}
-
 func (ms *messageAllowlistSampler) SampleMessage(lvl Level, msg string) bool {
 	for _, allow := range ms.Allow {
 		if msg == allow {
@@ -602,7 +596,7 @@ func (ms *messageAllowlistSampler) SampleMessage(lvl Level, msg string) bool {
 
 func TestMessageSampling(t *testing.T) {
 	out := &bytes.Buffer{}
-	log := New(out).Sample(&messageAllowlistSampler{
+	log := New(out).SampleMessages(&messageAllowlistSampler{
 		Allow: []string{"a", "c"},
 	})
 

--- a/sampler.go
+++ b/sampler.go
@@ -24,30 +24,15 @@ type Sampler interface {
 
 // MessageSampler samples logged messages.
 //
-// It provides two hooks to control sampling:
+// It is independent from the Sampler interface to allow
+// for sampling based on message contents.
 //
-//   - Sample is called initially to sample based on level.
-//   - SampleMessage is called only if Sample returned true
-//     to sample based on message contents.
+// If a Sampler is also provided to the logger,
+// the MessageSampler is only called if the Sampler returns true.
 type MessageSampler interface {
-	Sampler
-
 	// SampleMessage reports whether an event with the given level and message
 	// should be part of the sample.
-	//
-	// SampleMessage is called only if Sample returned true.
 	SampleMessage(lvl Level, msg string) bool
-}
-
-// MessageSamplerAdapter adapts a Sampler to a MessageSampler.
-type MessageSamplerAdapter struct {
-	Sampler
-}
-
-// SampleMessage ignores message contents as part of the sampling decision,
-// deferring to the decision made by Sampler.Sample.
-func (s MessageSamplerAdapter) SampleMessage(lvl Level, msg string) bool {
-	return true
 }
 
 // RandomSampler use a PRNG to randomly sample an event out of N events,

--- a/sampler.go
+++ b/sampler.go
@@ -22,6 +22,34 @@ type Sampler interface {
 	Sample(lvl Level) bool
 }
 
+// MessageSampler samples logged messages.
+//
+// It provides two hooks to control sampling:
+//
+//   - Sample is called initially to sample based on level.
+//   - SampleMessage is called only if Sample returned true
+//     to sample based on message contents.
+type MessageSampler interface {
+	Sampler
+
+	// SampleMessage reports whether an event with the given level and message
+	// should be part of the sample.
+	//
+	// SampleMessage is called only if Sample returned true.
+	SampleMessage(lvl Level, msg string) bool
+}
+
+// MessageSamplerAdapter adapts a Sampler to a MessageSampler.
+type MessageSamplerAdapter struct {
+	Sampler
+}
+
+// SampleMessage ignores message contents as part of the sampling decision,
+// deferring to the decision made by Sampler.Sample.
+func (s MessageSamplerAdapter) SampleMessage(lvl Level, msg string) bool {
+	return true
+}
+
 // RandomSampler use a PRNG to randomly sample an event out of N events,
 // regardless of their level.
 type RandomSampler uint32

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -70,22 +70,6 @@ func TestSamplers(t *testing.T) {
 	}
 }
 
-func TestMessageSamplerAdapter(t *testing.T) {
-	sampler := &BasicSampler{N: 5}
-	adapter := MessageSamplerAdapter{sampler}
-
-	var got int
-	for i := 0; i < 100; i++ {
-		if adapter.Sample(0) && adapter.SampleMessage(0, "") {
-			got++
-		}
-	}
-
-	if got != 20 {
-		t.Errorf(`MessageSamplerAdapter.Sample(0) == true %d on 100, want 20`, got)
-	}
-}
-
 func BenchmarkSamplers(b *testing.B) {
 	for i := range samplers {
 		s := samplers[i]

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -1,3 +1,4 @@
+//go:build !binary_log
 // +build !binary_log
 
 package zerolog
@@ -66,6 +67,22 @@ func TestSamplers(t *testing.T) {
 				t.Errorf("%s.Sample(0) == true %d on %d, want [%d, %d]", s.name, got, s.total, s.wantMin, s.wantMax)
 			}
 		})
+	}
+}
+
+func TestMessageSamplerAdapter(t *testing.T) {
+	sampler := &BasicSampler{N: 5}
+	adapter := MessageSamplerAdapter{sampler}
+
+	var got int
+	for i := 0; i < 100; i++ {
+		if adapter.Sample(0) && adapter.SampleMessage(0, "") {
+			got++
+		}
+	}
+
+	if got != 20 {
+		t.Errorf(`MessageSamplerAdapter.Sample(0) == true %d on 100, want 20`, got)
 	}
 }
 


### PR DESCRIPTION
zerolog's Sampler interface is currently limited
to sampling on the log level.
This makes it difficult to build a smarter sampler
that suppresses repetitive log messages
while still surfacing unique messages.
For comparison, Zap uses `(level, msg)` as the sampling key[^1],
which allows it to do the above.

[^1]: https://github.com/uber-go/zap/blob/v1.24.0/zapcore/sampler.go#L221

This change proposes a new interface, MessageSampler:

    type MessageSampler {
        SampleMessage(Level, string) bool
    }

There are two ways for us to incorporate this interface:
optional upgrade or independent concept.

For convenience, I've included both versions as separate commits.

### Optional upgrade

If the sampler passed to `Logger.Sample` implements this interface,
the SampleMessage method will be used by `*Event`
when it finally has access to the message content.

This turns the sampler interface into a two-stage thing.
We log only if `Sample(level) && SampleMessage(level, msg) == true`.
There's risk of confusion where a SampleMessage implementation
calls Sample again--double counting that message.

### Independent concept

We treat `MessageSampler` as an independent concept.
You can register a Sampler, a MessageSampler, neither, or both.

We still log only if `Sample(level) && SampleMessage(level, msg) == true`
but this time there's lower risk that a SampleMessage implementation
will call Sample because there's no expectation to satisfy both interfaces.

In exchange, this needs a new API:

    func (Logger) SampleMessages(MessageSamler) Logger

---

As I said, this PR contains both versions as separate commits.
I think *Independent concept* might make more sense,
but I'm interested in hearing which approach the maintainers prefer.

Resolves #543