### PR TITLE
stop using deprecated io/ioutils package

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -3,7 +3,7 @@ package zerolog
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -15,7 +15,7 @@ var (
 )
 
 func BenchmarkLogEmpty(b *testing.B) {
-	logger := New(ioutil.Discard)
+	logger := New(io.Discard)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -25,7 +25,7 @@ func BenchmarkLogEmpty(b *testing.B) {
 }
 
 func BenchmarkDisabled(b *testing.B) {
-	logger := New(ioutil.Discard).Level(Disabled)
+	logger := New(io.Discard).Level(Disabled)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -35,7 +35,7 @@ func BenchmarkDisabled(b *testing.B) {
 }
 
 func BenchmarkInfo(b *testing.B) {
-	logger := New(ioutil.Discard)
+	logger := New(io.Discard)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -45,7 +45,7 @@ func BenchmarkInfo(b *testing.B) {
 }
 
 func BenchmarkContextFields(b *testing.B) {
-	logger := New(ioutil.Discard).With().
+	logger := New(io.Discard).With().
 		Str("string", "four!").
 		Time("time", time.Time{}).
 		Int("int", 123).
@@ -60,7 +60,7 @@ func BenchmarkContextFields(b *testing.B) {
 }
 
 func BenchmarkContextAppend(b *testing.B) {
-	logger := New(ioutil.Discard).With().
+	logger := New(io.Discard).With().
 		Str("foo", "bar").
 		Logger()
 	b.ResetTimer()
@@ -72,7 +72,7 @@ func BenchmarkContextAppend(b *testing.B) {
 }
 
 func BenchmarkLogFields(b *testing.B) {
-	logger := New(ioutil.Discard)
+	logger := New(io.Discard)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -102,7 +102,7 @@ func BenchmarkLogArrayObject(b *testing.B) {
 	obj1 := obj{"a", "b", 2}
 	obj2 := obj{"c", "d", 3}
 	obj3 := obj{"e", "f", 4}
-	logger := New(ioutil.Discard)
+	logger := New(io.Discard)
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -224,7 +224,7 @@ func BenchmarkLogFieldType(b *testing.B) {
 			return e.Object("k", objects[0])
 		},
 	}
-	logger := New(ioutil.Discard)
+	logger := New(io.Discard)
 	b.ResetTimer()
 	for name := range types {
 		f := types[name]
@@ -358,7 +358,7 @@ func BenchmarkContextFieldType(b *testing.B) {
 			return c.Timestamp()
 		},
 	}
-	logger := New(ioutil.Discard)
+	logger := New(io.Discard)
 	b.ResetTimer()
 	for name := range types {
 		f := types[name]

--- a/binary_test.go
+++ b/binary_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	//	"io/ioutil"
 	stdlog "log"
 	"time"
 )

--- a/console_test.go
+++ b/console_test.go
@@ -3,7 +3,7 @@ package zerolog_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -474,7 +474,7 @@ func BenchmarkConsoleWriter(b *testing.B) {
 
 	var msg = []byte(`{"level": "info", "foo": "bar", "message": "HELLO", "time": "1990-01-01"}`)
 
-	w := zerolog.ConsoleWriter{Out: ioutil.Discard, NoColor: false}
+	w := zerolog.ConsoleWriter{Out: io.Discard, NoColor: false}
 
 	for i := 0; i < b.N; i++ {
 		w.Write(msg)

--- a/context.go
+++ b/context.go
@@ -3,7 +3,7 @@ package zerolog
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net"
 	"time"
@@ -57,7 +57,7 @@ func (c Context) Array(key string, arr LogArrayMarshaler) Context {
 
 // Object marshals an object that implement the LogObjectMarshaler interface.
 func (c Context) Object(key string, obj LogObjectMarshaler) Context {
-	e := newEvent(LevelWriterAdapter{ioutil.Discard}, 0)
+	e := newEvent(LevelWriterAdapter{io.Discard}, 0)
 	e.Object(key, obj)
 	c.l.context = enc.AppendObjectData(c.l.context, e.buf)
 	putEvent(e)
@@ -66,7 +66,7 @@ func (c Context) Object(key string, obj LogObjectMarshaler) Context {
 
 // EmbedObject marshals and Embeds an object that implement the LogObjectMarshaler interface.
 func (c Context) EmbedObject(obj LogObjectMarshaler) Context {
-	e := newEvent(LevelWriterAdapter{ioutil.Discard}, 0)
+	e := newEvent(LevelWriterAdapter{io.Discard}, 0)
 	e.EmbedObject(obj)
 	c.l.context = enc.AppendObjectData(c.l.context, e.buf)
 	putEvent(e)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2,13 +2,13 @@ package zerolog
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 )
 
 func TestCtx(t *testing.T) {
-	log := New(ioutil.Discard)
+	log := New(io.Discard)
 	ctx := log.WithContext(context.Background())
 	log2 := Ctx(ctx)
 	if !reflect.DeepEqual(log, *log2) {
@@ -37,13 +37,13 @@ func TestCtx(t *testing.T) {
 }
 
 func TestCtxDisabled(t *testing.T) {
-	dl := New(ioutil.Discard).Level(Disabled)
+	dl := New(io.Discard).Level(Disabled)
 	ctx := dl.WithContext(context.Background())
 	if ctx != context.Background() {
 		t.Error("WithContext stored a disabled logger")
 	}
 
-	l := New(ioutil.Discard).With().Str("foo", "bar").Logger()
+	l := New(io.Discard).With().Str("foo", "bar").Logger()
 	ctx = l.WithContext(ctx)
 	if !reflect.DeepEqual(Ctx(ctx), &l) {
 		t.Error("WithContext did not store logger")

--- a/diode/diode_test.go
+++ b/diode/diode_test.go
@@ -3,7 +3,6 @@ package diode_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -39,7 +38,7 @@ func TestClose(t *testing.T) {
 }
 
 func Benchmark(b *testing.B) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	defer log.SetOutput(os.Stderr)
 	benchs := map[string]time.Duration{
 		"Waiter": 0,
@@ -47,7 +46,7 @@ func Benchmark(b *testing.B) {
 	}
 	for name, interval := range benchs {
 		b.Run(name, func(b *testing.B) {
-			w := diode.NewWriter(ioutil.Discard, 100000, interval, nil)
+			w := diode.NewWriter(io.Discard, 100000, interval, nil)
 			log := zerolog.New(w)
 			defer w.Close()
 

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -333,10 +332,10 @@ func BenchmarkHandlers(b *testing.B) {
 	}))
 	h2 := MethodHandler("method")(RequestHandler("request")(h1))
 	handlers := map[string]http.Handler{
-		"Single":           NewHandler(zerolog.New(ioutil.Discard))(h1),
-		"Combined":         NewHandler(zerolog.New(ioutil.Discard))(h2),
-		"SingleDisabled":   NewHandler(zerolog.New(ioutil.Discard).Level(zerolog.Disabled))(h1),
-		"CombinedDisabled": NewHandler(zerolog.New(ioutil.Discard).Level(zerolog.Disabled))(h2),
+		"Single":           NewHandler(zerolog.New(io.Discard))(h1),
+		"Combined":         NewHandler(zerolog.New(io.Discard))(h2),
+		"SingleDisabled":   NewHandler(zerolog.New(io.Discard).Level(zerolog.Disabled))(h1),
+		"CombinedDisabled": NewHandler(zerolog.New(io.Discard).Level(zerolog.Disabled))(h2),
 	}
 	for name := range handlers {
 		h := handlers[name]

--- a/hook_test.go
+++ b/hook_test.go
@@ -3,7 +3,7 @@ package zerolog
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -172,7 +172,7 @@ func TestHook(t *testing.T) {
 }
 
 func BenchmarkHooks(b *testing.B) {
-	logger := New(ioutil.Discard)
+	logger := New(io.Discard)
 	b.ResetTimer()
 	b.Run("Nop/Single", func(b *testing.B) {
 		log := logger.Hook(nopHook)

--- a/log.go
+++ b/log.go
@@ -118,7 +118,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -246,7 +245,7 @@ type Logger struct {
 // you may consider using sync wrapper.
 func New(w io.Writer) Logger {
 	if w == nil {
-		w = ioutil.Discard
+		w = io.Discard
 	}
 	lw, ok := w.(LevelWriter)
 	if !ok {


### PR DESCRIPTION
The io/ioutils is deprecated. As of Go 1.16, the same functionality is now provided by packages "io" or "os".

See also https://pkg.go.dev/io/ioutil