### PR TITLE
Fixed documentation with tracing hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ and facilitates the unification of logging and tracing in some systems:
 type TracingHook struct{}
 
 func (h TracingHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
-    ctx := e.Ctx()
+    ctx := e.GetCtx()
     spanId := getSpanIdFromContext(ctx) // as per your tracing framework
     e.Str("span-id", spanId)
 }


### PR DESCRIPTION
The existing syntax mentioned in the README for retrieving context didn't work for me.
Just fixing it with what worked for me, referring the test cases mentioned in #559 