### PR TITLE
Fixed failing tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ and facilitates the unification of logging and tracing in some systems:
 type TracingHook struct{}
 
 func (h TracingHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
-    ctx := e.Ctx()
+    ctx := e.GetCtx()
     spanId := getSpanIdFromContext(ctx) // as per your tracing framework
     e.Str("span-id", spanId)
 }

--- a/diode/diode_test.go
+++ b/diode/diode_test.go
@@ -3,6 +3,7 @@ package diode_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"testing"

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"


### PR DESCRIPTION
Tests were failing since the import of package "io" was not found in test files, this fixes it by adding the required import.