### PR TITLE
Refactor: change Hook(h Hook) to Hook(hooks ...Hook)

### DIFF
--- a/log.go
+++ b/log.go
@@ -325,10 +325,10 @@ func (l Logger) Sample(s Sampler) Logger {
 }
 
 // Hook returns a logger with the h Hook.
-func (l Logger) Hook(h Hook) Logger {
-	newHooks := make([]Hook, len(l.hooks), len(l.hooks)+1)
+func (l Logger) Hook(hooks ...Hook) Logger {
+	newHooks := make([]Hook, len(l.hooks), len(l.hooks)+len(hooks))
 	copy(newHooks, l.hooks)
-	l.hooks = append(newHooks, h)
+	l.hooks = append(newHooks, hooks...)
 	return l
 }
 

--- a/log.go
+++ b/log.go
@@ -326,6 +326,9 @@ func (l Logger) Sample(s Sampler) Logger {
 
 // Hook returns a logger with the h Hook.
 func (l Logger) Hook(hooks ...Hook) Logger {
+	if len(hooks) == 0 {
+		return l
+	}
 	newHooks := make([]Hook, len(l.hooks), len(l.hooks)+len(hooks))
 	copy(newHooks, l.hooks)
 	l.hooks = append(newHooks, hooks...)

--- a/log_example_test.go
+++ b/log_example_test.go
@@ -72,7 +72,7 @@ func ExampleLogger_Hook() {
 	var levelNameHook LevelNameHook
 	var messageHook MessageHook = "The message"
 
-	log := zerolog.New(os.Stdout).Hook(levelNameHook).Hook(messageHook)
+	log := zerolog.New(os.Stdout).Hook(levelNameHook, messageHook)
 
 	log.Info().Msg("hello world")
 


### PR DESCRIPTION
This PR add support for setting multiple hooks at one time, without multiple times of deep copy (compare to call `Hook()` multi-times)

Also,  `func (l Logger) Hook(hooks ...Hook) Logger {}` is compatible with `func (l Logger) Hook(h Hook) Logger {}`