### PR TITLE
stop using deprecated CloseNotifier

### DIFF
--- a/hlog/internal/mutil/writer_proxy.go
+++ b/hlog/internal/mutil/writer_proxy.go
@@ -153,5 +153,4 @@ var (
 	_ http.Flusher       = &fancyWriter{}
 	_ http.Hijacker      = &fancyWriter{}
 	_ io.ReaderFrom      = &fancyWriter{}
-	_ http.Flusher       = &flushWriter{}
 )

--- a/hlog/internal/mutil/writer_proxy1_8.go
+++ b/hlog/internal/mutil/writer_proxy1_8.go
@@ -1,5 +1,5 @@
-//go:build !go1.8
-// +build !go1.8
+//go:build go1.8
+// +build go1.8
 
 package mutil
 
@@ -33,17 +33,13 @@ type WriterProxy interface {
 // WrapWriter wraps an http.ResponseWriter, returning a proxy that allows you to
 // hook into various parts of the response process.
 func WrapWriter(w http.ResponseWriter) WriterProxy {
-	_, cn := w.(http.CloseNotifier)
 	_, fl := w.(http.Flusher)
 	_, hj := w.(http.Hijacker)
 	_, rf := w.(io.ReaderFrom)
 
 	bw := basicWriter{ResponseWriter: w}
-	if cn && fl && hj && rf {
+	if fl && hj && rf {
 		return &fancyWriter{bw}
-	}
-	if fl {
-		return &flushWriter{bw}
 	}
 	return &bw
 }
@@ -102,7 +98,7 @@ func (b *basicWriter) Unwrap() http.ResponseWriter {
 	return b.ResponseWriter
 }
 
-// fancyWriter is a writer that additionally satisfies http.CloseNotifier,
+// fancyWriter is a writer that additionally satisfies http.Pusher,
 // http.Flusher, http.Hijacker, and io.ReaderFrom. It exists for the common case
 // of wrapping the http.ResponseWriter that package http gives you, in order to
 // make the proxied object support the full method set of the proxied object.
@@ -110,9 +106,8 @@ type fancyWriter struct {
 	basicWriter
 }
 
-func (f *fancyWriter) CloseNotify() <-chan bool {
-	cn := f.basicWriter.ResponseWriter.(http.CloseNotifier)
-	return cn.CloseNotify()
+func (f *fancyWriter) Push(target string, opts *http.PushOptions) error {
+	return f.basicWriter.ResponseWriter.(http.Pusher).Push(target, opts)
 }
 
 func (f *fancyWriter) Flush() {
@@ -127,31 +122,16 @@ func (f *fancyWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 
 func (f *fancyWriter) ReadFrom(r io.Reader) (int64, error) {
 	if f.basicWriter.tee != nil {
-		n, err := io.Copy(&f.basicWriter, r)
-		f.bytes += int(n)
-		return n, err
+		return io.Copy(&f.basicWriter, r)
 	}
 	rf := f.basicWriter.ResponseWriter.(io.ReaderFrom)
 	f.basicWriter.maybeWriteHeader()
-
-	n, err := rf.ReadFrom(r)
-	f.bytes += int(n)
-	return n, err
-}
-
-type flushWriter struct {
-	basicWriter
-}
-
-func (f *flushWriter) Flush() {
-	fl := f.basicWriter.ResponseWriter.(http.Flusher)
-	fl.Flush()
+	return rf.ReadFrom(r)
 }
 
 var (
-	_ http.CloseNotifier = &fancyWriter{}
-	_ http.Flusher       = &fancyWriter{}
-	_ http.Hijacker      = &fancyWriter{}
-	_ io.ReaderFrom      = &fancyWriter{}
-	_ http.Flusher       = &flushWriter{}
+	_ http.Pusher   = &fancyWriter{}
+	_ http.Flusher  = &fancyWriter{}
+	_ http.Hijacker = &fancyWriter{}
+	_ io.ReaderFrom = &fancyWriter{}
 )

--- a/hlog/internal/mutil/writer_proxy1_8.go
+++ b/hlog/internal/mutil/writer_proxy1_8.go
@@ -106,10 +106,6 @@ type fancyWriter struct {
 	basicWriter
 }
 
-func (f *fancyWriter) Push(target string, opts *http.PushOptions) error {
-	return f.basicWriter.ResponseWriter.(http.Pusher).Push(target, opts)
-}
-
 func (f *fancyWriter) Flush() {
 	fl := f.basicWriter.ResponseWriter.(http.Flusher)
 	fl.Flush()
@@ -130,7 +126,6 @@ func (f *fancyWriter) ReadFrom(r io.Reader) (int64, error) {
 }
 
 var (
-	_ http.Pusher   = &fancyWriter{}
 	_ http.Flusher  = &fancyWriter{}
 	_ http.Hijacker = &fancyWriter{}
 	_ io.ReaderFrom = &fancyWriter{}


### PR DESCRIPTION
CloseNotifier is deprecated since go1.11. If using go 1.8 or higher preferred to use context instead. 