### PR TITLE
Make Log.Fatal() call Close on the writer before os.Exit(1)

### DIFF
--- a/log.go
+++ b/log.go
@@ -387,7 +387,14 @@ func (l *Logger) Err(err error) *Event {
 //
 // You must call Msg on the returned event in order to send the event.
 func (l *Logger) Fatal() *Event {
-	return l.newEvent(FatalLevel, func(msg string) { os.Exit(1) })
+	return l.newEvent(FatalLevel, func(msg string) {
+		if closer, ok := l.w.(io.Closer); ok {
+			// Close the writer to flush any buffered message. Otherwise the message
+			// will be lost as os.Exit() terminates the program immediately.
+			closer.Close()
+		}
+		os.Exit(1)
+	})
 }
 
 // Panic starts a new message with panic level. The panic() function


### PR DESCRIPTION
This fixes the footgun where log.Fatal() does not actually write any messages when used with any kind of buffered writer such as the diode writer.