### PR TITLE
Fix prettylog piping

### DIFF
--- a/cmd/prettylog/prettylog.go
+++ b/cmd/prettylog/prettylog.go
@@ -19,7 +19,18 @@ func main() {
 	writer := zerolog.NewConsoleWriter()
 
 	if isInputFromPipe() {
-		_, _ = io.Copy(writer, os.Stdin)
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			bytesToWrite := scanner.Bytes()
+			_, err := writer.Write(bytesToWrite)
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				fmt.Printf("%s\n", bytesToWrite)
+			}
+		}
 	} else if len(os.Args) > 1 {
 		for _, filename := range os.Args[1:] {
 			// Scan each line from filename and write it into writer

--- a/cmd/prettylog/prettylog.go
+++ b/cmd/prettylog/prettylog.go
@@ -15,42 +15,39 @@ func isInputFromPipe() bool {
 	return fileInfo.Mode()&os.ModeCharDevice == 0
 }
 
-func main() {
+func processInput(reader io.Reader) error {
 	writer := zerolog.NewConsoleWriter()
 
-	if isInputFromPipe() {
-		scanner := bufio.NewScanner(os.Stdin)
-		for scanner.Scan() {
-			bytesToWrite := scanner.Bytes()
-			_, err := writer.Write(bytesToWrite)
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-
-				fmt.Printf("%s\n", bytesToWrite)
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		bytesToWrite := scanner.Bytes()
+		_, err := writer.Write(bytesToWrite)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
 			}
+
+			fmt.Printf("%s\n", bytesToWrite)
 		}
+	}
+
+	return scanner.Err()
+}
+
+func main() {
+
+	if isInputFromPipe() {
+		_ = processInput(os.Stdin)
 	} else if len(os.Args) > 1 {
 		for _, filename := range os.Args[1:] {
 			// Scan each line from filename and write it into writer
-			r, err := os.Open(filename)
+			reader, err := os.Open(filename)
 			if err != nil {
 				fmt.Printf("%s open: %v", filename, err)
 				os.Exit(1)
 			}
-			scanner := bufio.NewScanner(r)
-			for scanner.Scan() {
-				_, err = writer.Write(scanner.Bytes())
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					fmt.Printf("%s write: %v", filename, err)
-					os.Exit(1)
-				}
-			}
-			if err := scanner.Err(); err != nil {
+
+			if err := processInput(reader); err != nil {
 				fmt.Printf("%s scan: %v", filename, err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
Fixes #628.

Basically, instead of directly piping the output from pipe, it now reads it via bufio.Scanner, which splits events by newline, so if the input is buffered, it groups logs by splitting events by newline, and in case it fails, it would just output the logs directly.

Example on testing it:
1) broken output (e.g. the whole string is invalid JSON as it's essentially split into two chunks by a newline) - displays the input as it is:
```
➜  prettylog git:(fix-prettylog-piping) ✗ cat test.sh
while true; do
echo '{"level":"info","module":"txindex","height":18397037,"tim';
sleep 0.5;
echo 'e":"2023-12-23T02:13:47+03:00","message":"indexed block exents"}'
sleep 0.5
done

➜  prettylog git:(fix-prettylog-piping) ✗ bash test.sh | ./prettylog
{"level":"info","module":"txindex","height":18397037,"tim
e":"2023-12-23T02:13:47+03:00","message":"indexed block exents"}
{"level":"info","module":"txindex","height":18397037,"tim
e":"2023-12-23T02:13:47+03:00","message":"indexed block exents"}
```

2) chunked output - displays output as pretty logs
```
➜  prettylog git:(fix-prettylog-piping) ✗
➜  prettylog git:(fix-prettylog-piping) ✗ cat test.sh
while true; do
echo -n '{"level":"info","module":"txindex","height":18397037,"tim';
sleep 0.5;
echo 'e":"2023-12-23T02:13:47+03:00","message":"indexed block exents"}'
sleep 0.5
done

➜  prettylog git:(fix-prettylog-piping) ✗ bash test.sh | ./prettylog
2:13AM INF indexed block exents height=18397037 module=txindex
2:13AM INF indexed block exents height=18397037 module=txindex
2:13AM INF indexed block exents height=18397037 module=txindex
2:13AM INF indexed block exents height=18397037 module=txindex
2:13AM INF indexed block exents height=18397037 module=txindex
```

3) ideal output (nothing is buffered, whatever is piping data into prettylog splits it by the newline) - displays output as pretty logs
```
➜  prettylog git:(fix-prettylog-piping) ✗ cat test.sh
while true; do
echo '{"level":"info","module":"txindex","height":18397037,"time":"2023-12-23T02:13:47+03:00","message":"indexed block exents"}'
sleep 0.5
done
➜  prettylog git:(fix-prettylog-piping) ✗ bash test.sh | ./prettylog
2:13AM INF indexed block exents height=18397037 module=txindex
2:13AM INF indexed block exents height=18397037 module=txindex
2:13AM INF indexed block exents height=18397037 module=txindex
2:13AM INF indexed block exents height=18397037 module=txindex
```