### PR TITLE
Fix phsym/zeroslog breakage due to rs/zerolog v1.32.0

### DIFF
--- a/context.go
+++ b/context.go
@@ -14,6 +14,11 @@ type Context struct {
 	l Logger
 }
 
+func NewContextWithResetLogger(l Logger) Context {
+	l.context = enc.AppendBeginMarker(make([]byte, 0, 500))
+	return Context{l: l}
+}
+
 // Logger returns the logger with the context previously set.
 func (c Context) Logger() Logger {
 	return c.l

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rs/zerolog
+module github.com/madkins23/zerolog
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/madkins23/zerolog
+module github.com/rs/zerolog
 
 go 1.15
 


### PR DESCRIPTION
TL;DR Add function to create a zerolog.Context object with a logger copy and clear the copy's context byte array in order to fix breakage in `phsym/zeroslog`.

The recent release of `rs/zerolog v1.32.0` broke `phsym/zeroslog`. The latter was creating blank `zerolog.Context` objects in several places and they worked fine up through `rs/zerolog v1.31.0`. I documented the issue in a [`phsym/zeroslog` PR](https://github.com/phsym/zeroslog/pull/4), wherein I provided a potential solution to the issue that didn't require any changes to `rs/zerolog`.

This PR provides a (hopefully) minor change to `rs/zerolog` that makes fixing `phsym/zeroslog` simpler. I have already filed a second presumptive [`phsym/zeroslog` PR](https://github.com/phsym/zeroslog/pull/6) dependent on the changes in this `rs/zerolog` PR.

Hopefully this PR will be an acceptable and minor change.

I gave the new function a long name because it is combining two issues. It could be broken down into:

* `NewContext(logger Logger)`  
  which would just create the new `zerolog.Context` object with a logger and
* `(l Logger) ClearContext()`  
  which would clear the `context` byte array on the copied `Logger`.

These two calls could be used instead of the single `NewContextWithResetLogger` call, something like this:
```Go
newCtx := NewContext(logger)
newCtx.Logger().ClearContext()
```

If the latter is preferable I can generate a different PR.