### PR TITLE
fix: use `TimestampFunc` in busrt sampler (#671)

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -84,7 +84,7 @@ func (s *BurstSampler) Sample(lvl Level) bool {
 }
 
 func (s *BurstSampler) inc() uint32 {
-	now := time.Now().UnixNano()
+	now := TimestampFunc().UnixNano()
 	resetAt := atomic.LoadInt64(&s.resetAt)
 	var c uint32
 	if now > resetAt {


### PR DESCRIPTION
As reported in #671 I submit this easy fix to use`zerolog` in testing or accelerated simulation environments.