### PR TITLE
fix: correct field filtering logic in writeFields

### DIFF
--- a/console.go
+++ b/console.go
@@ -190,10 +190,16 @@ func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer
 			continue
 		}
 
-		switch field {
-		case LevelFieldName, TimestampFieldName, MessageFieldName, CallerFieldName:
+		for _, excluded := range w.PartsOrder {
+			if field == excluded {
+				isExcluded = true
+				break
+			}
+		}
+		if isExcluded {
 			continue
 		}
+
 		fields = append(fields, field)
 	}
 


### PR DESCRIPTION
`ConsoleWriter.Write` processes custom fields specified in `PartsOrder` to output only their values instead of the key-value pairs. In practice:
```go
package main

import (
	"github.com/rs/zerolog"
)

func main() {
	cw := zerolog.NewConsoleWriter()
	cw.PartsOrder = append(cw.PartsOrder, "k1")
	logger := zerolog.New(cw).With().Timestamp().Logger()
	logger.Info().Str("k1", "v1").Msg("hello world")
}
```

Actual output:

```
5:09PM INF hello world v1 k1=v1
```

The field `k1` is duplicated, and the expected output is:

```
5:09PM INF hello world v1
```

This is due to a bug in `ConsoleWrite.writeFields` where it filters fields based on the default `PartsOrder` rather than the current `PartsOrder`.