### PR TITLE
feat: Add method to get event fields

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,7 +1,9 @@
 package zerolog
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -827,4 +829,20 @@ func (e *Event) MACAddr(key string, ha net.HardwareAddr) *Event {
 	}
 	e.buf = enc.AppendMACAddr(enc.AppendKey(e.buf, key), ha)
 	return e
+}
+
+func (e *Event) GetFields() (map[string]interface{}, error) {
+	if e == nil {
+		return nil, nil
+	}
+
+	eventFields := make(map[string]interface{})
+	buffer := e.buf
+	if !bytes.HasSuffix(e.buf, []byte("}\n")) {
+		buffer = append(e.buf, '}')
+	}
+	if err := json.Unmarshal(buffer, &eventFields); err != nil {
+		return nil, err
+	}
+	return eventFields, nil
 }

--- a/event_test.go
+++ b/event_test.go
@@ -1,3 +1,4 @@
+//go:build !binary_log
 // +build !binary_log
 
 package zerolog
@@ -61,5 +62,29 @@ func TestEvent_EmbedObjectWithNil(t *testing.T) {
 	got := strings.TrimSpace(buf.String())
 	if got != want {
 		t.Errorf("Event.EmbedObject() = %q, want %q", got, want)
+	}
+}
+
+func TestEvent_GetFields(t *testing.T) {
+	e := newEvent(nil, DebugLevel)
+	e.Str("foo", "bar").Float64("n", 42).Msg("test")
+
+	got, err := e.GetFields()
+	if err != nil {
+		t.Error(err)
+	}
+	want := map[string]interface{}{
+		"foo":     "bar",
+		"n":       float64(42),
+		"message": "test",
+	}
+
+	if len(got) != len(want) {
+		t.Errorf("Event.GetFields() = %v, want %v", len(got), len(want))
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("Event.GetFields() = %v, want %v", got[k], v)
+		}
 	}
 }


### PR DESCRIPTION
Hi 👋 Thank you for this great module 🚀 

Opening for feedback as an attempt to fix https://github.com/rs/zerolog/issues/493, https://github.com/rs/zerolog/issues/587, also referenced from https://github.com/open-telemetry/opentelemetry-go-contrib/pull/5918/files#diff-a9b82897838da6b8eed398e03c9590621e6c2336ff576b3a49fb684ff8bba2a1R110

This is not the cleanest approach, but could be better from using reflecting. It doesn't expose the internal buffer representation format so if it ever changes `GetFields` can be modifed.

Feedback very much welcomed