### PR TITLE
Make the BurstSampler more accurate, especially when resetting the count.

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -86,20 +86,14 @@ func (s *BurstSampler) Sample(lvl Level) bool {
 func (s *BurstSampler) inc() uint32 {
 	now := TimestampFunc().UnixNano()
 	resetAt := atomic.LoadInt64(&s.resetAt)
-	var c uint32
+	newResetAt := now + s.Period.Nanoseconds()
 	if now > resetAt {
-		c = 1
-		atomic.StoreUint32(&s.counter, c)
-		newResetAt := now + s.Period.Nanoseconds()
 		reset := atomic.CompareAndSwapInt64(&s.resetAt, resetAt, newResetAt)
-		if !reset {
-			// Lost the race with another goroutine trying to reset.
-			c = atomic.AddUint32(&s.counter, 1)
+		if reset {
+			atomic.StoreUint32(&s.counter, 0)
 		}
-	} else {
-		c = atomic.AddUint32(&s.counter, 1)
 	}
-	return c
+	return atomic.AddUint32(&s.counter, 1)
 }
 
 // LevelSampler applies a different sampler for each level.


### PR DESCRIPTION
After refactoring, the following test can pass.
```go
func TestBurstSampler(t *testing.T) {
	s := &BurstSampler{Burst: 20, Period: time.Millisecond * 200}
	wg := sync.WaitGroup{}
	wg.Add(2000)
	past := atomic.Int64{}
	start := time.Now()
	for i := 0; i < 2000; i++ {
		go func() {
			defer wg.Done()
			for {
				if s.Sample(0) {
					past.Add(1)
				}
				if time.Now().Sub(start) > time.Millisecond*210 {
					break
				}
			}
		}()
	}
	wg.Wait()
	if past.Load() != 40 {
		t.Errorf("got %d, want 40", past.Load())
	}
}
```