### PR TITLE
Add method for Deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ Find out [who uses zerolog](https://github.com/rs/zerolog/wiki/Who-uses-zerolog)
 
 ## Features
 
-* [Blazing fast](#benchmarks)
-* [Low to zero allocation](#benchmarks)
-* [Leveled logging](#leveled-logging)
-* [Sampling](#log-sampling)
-* [Hooks](#hooks)
-* [Contextual fields](#contextual-logging)
-* [`context.Context` integration](#contextcontext-integration)
-* [Integration with `net/http`](#integration-with-nethttp)
-* [JSON and CBOR encoding formats](#binary-encoding)
-* [Pretty logging for development](#pretty-logging)
-* [Error Logging (with optional Stacktrace)](#error-logging)
+- [Blazing fast](#benchmarks)
+- [Low to zero allocation](#benchmarks)
+- [Leveled logging](#leveled-logging)
+- [Sampling](#log-sampling)
+- [Hooks](#hooks)
+- [Contextual fields](#contextual-logging)
+- [`context.Context` integration](#contextcontext-integration)
+- [Integration with `net/http`](#integration-with-nethttp)
+- [JSON and CBOR encoding formats](#binary-encoding)
+- [Pretty logging for development](#pretty-logging)
+- [Error Logging (with optional Stacktrace)](#error-logging)
 
 ## Installation
 
@@ -59,8 +59,9 @@ func main() {
 
 // Output: {"time":1516134303,"level":"debug","message":"hello world"}
 ```
+
 > Note: By default log writes to `os.Stderr`
-> Note: The default log level for `log.Print` is *trace*
+> Note: The default log level for `log.Print` is _trace_
 
 ### Contextual Logging
 
@@ -81,7 +82,7 @@ func main() {
         Str("Scale", "833 cents").
         Float64("Interval", 833.09).
         Msg("Fibonacci is everywhere")
-    
+
     log.Debug().
         Str("Name", "Tom").
         Send()
@@ -118,15 +119,15 @@ func main() {
 
 **zerolog** allows for logging at the following levels (from highest to lowest):
 
-* panic (`zerolog.PanicLevel`, 5)
-* fatal (`zerolog.FatalLevel`, 4)
-* error (`zerolog.ErrorLevel`, 3)
-* warn (`zerolog.WarnLevel`, 2)
-* info (`zerolog.InfoLevel`, 1)
-* debug (`zerolog.DebugLevel`, 0)
-* trace (`zerolog.TraceLevel`, -1)
+- panic (`zerolog.PanicLevel`, 5)
+- fatal (`zerolog.FatalLevel`, 4)
+- error (`zerolog.ErrorLevel`, 3)
+- warn (`zerolog.WarnLevel`, 2)
+- info (`zerolog.InfoLevel`, 1)
+- debug (`zerolog.DebugLevel`, 0)
+- trace (`zerolog.TraceLevel`, -1)
 
-You can set the Global logging level to any of these options using the `SetGlobalLevel` function in the zerolog package, passing in one of the given constants above, e.g. `zerolog.InfoLevel` would be the "info" level.  Whichever level is chosen, all logs with a level greater than or equal to that level will be written. To turn off logging entirely, pass the `zerolog.Disabled` constant.
+You can set the Global logging level to any of these options using the `SetGlobalLevel` function in the zerolog package, passing in one of the given constants above, e.g. `zerolog.InfoLevel` would be the "info" level. Whichever level is chosen, all logs with a level greater than or equal to that level will be written. To turn off logging entirely, pass the `zerolog.Disabled` constant.
 
 #### Setting Global Log Level
 
@@ -232,7 +233,7 @@ func main() {
 
 #### Error Logging with Stacktrace
 
-Using `github.com/pkg/errors`, you can add a formatted stacktrace to your errors. 
+Using `github.com/pkg/errors`, you can add a formatted stacktrace to your errors.
 
 ```go
 package main
@@ -307,7 +308,6 @@ func main() {
 ```
 
 > NOTE: Using `Msgf` generates one allocation even when the logger is disabled.
-
 
 ### Create logger instance to manage different outputs
 
@@ -506,7 +506,7 @@ stdlog.Print("hello world")
 ### context.Context integration
 
 Go contexts are commonly passed throughout Go code, and this can help you pass
-your Logger into places it might otherwise be hard to inject.  The `Logger`
+your Logger into places it might otherwise be hard to inject. The `Logger`
 instance may be attached to Go context (`context.Context`) using
 `Logger.WithContext(ctx)` and extracted from it using `zerolog.Ctx(ctx)`.
 For example:
@@ -531,7 +531,7 @@ func someFunc(ctx context.Context) {
 ```
 
 A second form of `context.Context` integration allows you to pass the current
-context.Context into the logged event, and retrieve it from hooks.  This can be
+context.Context into the logged event, and retrieve it from hooks. This can be
 useful to log trace and span IDs or other information stored in the go context,
 and facilitates the unification of logging and tracing in some systems:
 
@@ -609,8 +609,10 @@ if err := http.ListenAndServe(":8080", nil); err != nil {
 ```
 
 ## Multiple Log Output
-`zerolog.MultiLevelWriter` may be used to send the log message to multiple outputs. 
+
+`zerolog.MultiLevelWriter` may be used to send the log message to multiple outputs.
 In this example, we send the log message to both `os.Stdout` and the in-built ConsoleWriter.
+
 ```go
 func main() {
 	consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
@@ -631,43 +633,43 @@ func main() {
 
 Some settings can be changed and will be applied to all loggers:
 
-* `log.Logger`: You can set this value to customize the global logger (the one used by package level methods).
-* `zerolog.SetGlobalLevel`: Can raise the minimum level of all loggers. Call this with `zerolog.Disabled` to disable logging altogether (quiet mode).
-* `zerolog.DisableSampling`: If argument is `true`, all sampled loggers will stop sampling and issue 100% of their log events.
-* `zerolog.TimestampFieldName`: Can be set to customize `Timestamp` field name.
-* `zerolog.LevelFieldName`: Can be set to customize level field name.
-* `zerolog.MessageFieldName`: Can be set to customize message field name.
-* `zerolog.ErrorFieldName`: Can be set to customize `Err` field name.
-* `zerolog.TimeFieldFormat`: Can be set to customize `Time` field value formatting. If set with `zerolog.TimeFormatUnix`, `zerolog.TimeFormatUnixMs` or `zerolog.TimeFormatUnixMicro`, times are formatted as UNIX timestamp.
-* `zerolog.DurationFieldUnit`: Can be set to customize the unit for time.Duration type fields added by `Dur` (default: `time.Millisecond`).
-* `zerolog.DurationFieldInteger`: If set to `true`, `Dur` fields are formatted as integers instead of floats (default: `false`). 
-* `zerolog.ErrorHandler`: Called whenever zerolog fails to write an event on its output. If not set, an error is printed on the stderr. This handler must be thread safe and non-blocking.
-* `zerolog.FloatingPointPrecision`: If set to a value other than -1, controls the number
-of digits when formatting float numbers in JSON. See
-[strconv.FormatFloat](https://pkg.go.dev/strconv#FormatFloat)
-for more details.
+- `log.Logger`: You can set this value to customize the global logger (the one used by package level methods).
+- `zerolog.SetGlobalLevel`: Can raise the minimum level of all loggers. Call this with `zerolog.Disabled` to disable logging altogether (quiet mode).
+- `zerolog.DisableSampling`: If argument is `true`, all sampled loggers will stop sampling and issue 100% of their log events.
+- `zerolog.TimestampFieldName`: Can be set to customize `Timestamp` field name.
+- `zerolog.LevelFieldName`: Can be set to customize level field name.
+- `zerolog.MessageFieldName`: Can be set to customize message field name.
+- `zerolog.ErrorFieldName`: Can be set to customize `Err` field name.
+- `zerolog.TimeFieldFormat`: Can be set to customize `Time` field value formatting. If set with `zerolog.TimeFormatUnix`, `zerolog.TimeFormatUnixMs` or `zerolog.TimeFormatUnixMicro`, times are formatted as UNIX timestamp.
+- `zerolog.DurationFieldUnit`: Can be set to customize the unit for time.Duration type fields added by `Dur` (default: `time.Millisecond`).
+- `zerolog.DurationFieldInteger`: If set to `true`, `Dur` fields are formatted as integers instead of floats (default: `false`).
+- `zerolog.ErrorHandler`: Called whenever zerolog fails to write an event on its output. If not set, an error is printed on the stderr. This handler must be thread safe and non-blocking.
+- `zerolog.FloatingPointPrecision`: If set to a value other than -1, controls the number
+  of digits when formatting float numbers in JSON. See
+  [strconv.FormatFloat](https://pkg.go.dev/strconv#FormatFloat)
+  for more details.
 
 ## Field Types
 
 ### Standard Types
 
-* `Str`
-* `Bool`
-* `Int`, `Int8`, `Int16`, `Int32`, `Int64`
-* `Uint`, `Uint8`, `Uint16`, `Uint32`, `Uint64`
-* `Float32`, `Float64`
+- `Str`
+- `Bool`
+- `Int`, `Int8`, `Int16`, `Int32`, `Int64`
+- `Uint`, `Uint8`, `Uint16`, `Uint32`, `Uint64`
+- `Float32`, `Float64`
 
 ### Advanced Fields
 
-* `Err`: Takes an `error` and renders it as a string using the `zerolog.ErrorFieldName` field name.
-* `Func`: Run a `func` only if the level is enabled.
-* `Timestamp`: Inserts a timestamp field with `zerolog.TimestampFieldName` field name, formatted using `zerolog.TimeFieldFormat`.
-* `Time`: Adds a field with time formatted with `zerolog.TimeFieldFormat`.
-* `Dur`: Adds a field with `time.Duration`.
-* `Dict`: Adds a sub-key/value as a field of the event.
-* `RawJSON`: Adds a field with an already encoded JSON (`[]byte`)
-* `Hex`: Adds a field with value formatted as a hexadecimal string (`[]byte`)
-* `Interface`: Uses reflection to marshal the type.
+- `Err`: Takes an `error` and renders it as a string using the `zerolog.ErrorFieldName` field name.
+- `Func`: Run a `func` only if the level is enabled.
+- `Timestamp`: Inserts a timestamp field with `zerolog.TimestampFieldName` field name, formatted using `zerolog.TimeFieldFormat`.
+- `Time`: Adds a field with time formatted with `zerolog.TimeFieldFormat`.
+- `Dur`: Adds a field with `time.Duration`.
+- `Dict`: Adds a sub-key/value as a field of the event.
+- `RawJSON`: Adds a field with an already encoded JSON (`[]byte`)
+- `Hex`: Adds a field with value formatted as a hexadecimal string (`[]byte`)
+- `Interface`: Uses reflection to marshal the type.
 
 Most fields are also available in the slice format (`Strs` for `[]string`, `Errs` for `[]error` etc.)
 
@@ -684,15 +686,15 @@ with zerolog library is [CSD](https://github.com/toravir/csd/).
 
 ## Related Projects
 
-* [grpc-zerolog](https://github.com/cheapRoc/grpc-zerolog): Implementation of `grpclog.LoggerV2` interface using `zerolog`
-* [overlog](https://github.com/Trendyol/overlog): Implementation of `Mapped Diagnostic Context` interface using `zerolog`
-* [zerologr](https://github.com/go-logr/zerologr): Implementation of `logr.LogSink` interface using `zerolog`
+- [grpc-zerolog](https://github.com/cheapRoc/grpc-zerolog): Implementation of `grpclog.LoggerV2` interface using `zerolog`
+- [overlog](https://github.com/Trendyol/overlog): Implementation of `Mapped Diagnostic Context` interface using `zerolog`
+- [zerologr](https://github.com/go-logr/zerologr): Implementation of `logr.LogSink` interface using `zerolog`
 
 ## Benchmarks
 
 See [logbench](http://bench.zerolog.io/) for more comprehensive and up-to-date benchmarks.
 
-All operations are allocation free (those numbers *include* JSON encoding):
+All operations are allocation free (those numbers _include_ JSON encoding):
 
 ```text
 BenchmarkLogEmpty-8        100000000    19.1 ns/op     0 B/op       0 allocs/op
@@ -704,56 +706,56 @@ BenchmarkLogFields-8       10000000     184 ns/op      0 B/op       0 allocs/op
 
 There are a few Go logging benchmarks and comparisons that include zerolog.
 
-* [imkira/go-loggers-bench](https://github.com/imkira/go-loggers-bench)
-* [uber-common/zap](https://github.com/uber-go/zap#performance)
+- [imkira/go-loggers-bench](https://github.com/imkira/go-loggers-bench)
+- [uber-common/zap](https://github.com/uber-go/zap#performance)
 
 Using Uber's zap comparison benchmark:
 
 Log a message and 10 fields:
 
-| Library | Time | Bytes Allocated | Objects Allocated |
-| :--- | :---: | :---: | :---: |
-| zerolog | 767 ns/op | 552 B/op | 6 allocs/op |
-| :zap: zap | 848 ns/op | 704 B/op | 2 allocs/op |
-| :zap: zap (sugared) | 1363 ns/op | 1610 B/op | 20 allocs/op |
-| go-kit | 3614 ns/op | 2895 B/op | 66 allocs/op |
-| lion | 5392 ns/op | 5807 B/op | 63 allocs/op |
-| logrus | 5661 ns/op | 6092 B/op | 78 allocs/op |
-| apex/log | 15332 ns/op | 3832 B/op | 65 allocs/op |
-| log15 | 20657 ns/op | 5632 B/op | 93 allocs/op |
+| Library             |    Time     | Bytes Allocated | Objects Allocated |
+| :------------------ | :---------: | :-------------: | :---------------: |
+| zerolog             |  767 ns/op  |    552 B/op     |    6 allocs/op    |
+| :zap: zap           |  848 ns/op  |    704 B/op     |    2 allocs/op    |
+| :zap: zap (sugared) | 1363 ns/op  |    1610 B/op    |   20 allocs/op    |
+| go-kit              | 3614 ns/op  |    2895 B/op    |   66 allocs/op    |
+| lion                | 5392 ns/op  |    5807 B/op    |   63 allocs/op    |
+| logrus              | 5661 ns/op  |    6092 B/op    |   78 allocs/op    |
+| apex/log            | 15332 ns/op |    3832 B/op    |   65 allocs/op    |
+| log15               | 20657 ns/op |    5632 B/op    |   93 allocs/op    |
 
 Log a message with a logger that already has 10 fields of context:
 
-| Library | Time | Bytes Allocated | Objects Allocated |
-| :--- | :---: | :---: | :---: |
-| zerolog | 52 ns/op | 0 B/op | 0 allocs/op |
-| :zap: zap | 283 ns/op | 0 B/op | 0 allocs/op |
-| :zap: zap (sugared) | 337 ns/op | 80 B/op | 2 allocs/op |
-| lion | 2702 ns/op | 4074 B/op | 38 allocs/op |
-| go-kit | 3378 ns/op | 3046 B/op | 52 allocs/op |
-| logrus | 4309 ns/op | 4564 B/op | 63 allocs/op |
-| apex/log | 13456 ns/op | 2898 B/op | 51 allocs/op |
-| log15 | 14179 ns/op | 2642 B/op | 44 allocs/op |
+| Library             |    Time     | Bytes Allocated | Objects Allocated |
+| :------------------ | :---------: | :-------------: | :---------------: |
+| zerolog             |  52 ns/op   |     0 B/op      |    0 allocs/op    |
+| :zap: zap           |  283 ns/op  |     0 B/op      |    0 allocs/op    |
+| :zap: zap (sugared) |  337 ns/op  |     80 B/op     |    2 allocs/op    |
+| lion                | 2702 ns/op  |    4074 B/op    |   38 allocs/op    |
+| go-kit              | 3378 ns/op  |    3046 B/op    |   52 allocs/op    |
+| logrus              | 4309 ns/op  |    4564 B/op    |   63 allocs/op    |
+| apex/log            | 13456 ns/op |    2898 B/op    |   51 allocs/op    |
+| log15               | 14179 ns/op |    2642 B/op    |   44 allocs/op    |
 
 Log a static string, without any context or `printf`-style templating:
 
-| Library | Time | Bytes Allocated | Objects Allocated |
-| :--- | :---: | :---: | :---: |
-| zerolog | 50 ns/op | 0 B/op | 0 allocs/op |
-| :zap: zap | 236 ns/op | 0 B/op | 0 allocs/op |
-| standard library | 453 ns/op | 80 B/op | 2 allocs/op |
-| :zap: zap (sugared) | 337 ns/op | 80 B/op | 2 allocs/op |
-| go-kit | 508 ns/op | 656 B/op | 13 allocs/op |
-| lion | 771 ns/op | 1224 B/op | 10 allocs/op |
-| logrus | 1244 ns/op | 1505 B/op | 27 allocs/op |
-| apex/log | 2751 ns/op | 584 B/op | 11 allocs/op |
-| log15 | 5181 ns/op | 1592 B/op | 26 allocs/op |
+| Library             |    Time    | Bytes Allocated | Objects Allocated |
+| :------------------ | :--------: | :-------------: | :---------------: |
+| zerolog             |  50 ns/op  |     0 B/op      |    0 allocs/op    |
+| :zap: zap           | 236 ns/op  |     0 B/op      |    0 allocs/op    |
+| standard library    | 453 ns/op  |     80 B/op     |    2 allocs/op    |
+| :zap: zap (sugared) | 337 ns/op  |     80 B/op     |    2 allocs/op    |
+| go-kit              | 508 ns/op  |    656 B/op     |   13 allocs/op    |
+| lion                | 771 ns/op  |    1224 B/op    |   10 allocs/op    |
+| logrus              | 1244 ns/op |    1505 B/op    |   27 allocs/op    |
+| apex/log            | 2751 ns/op |    584 B/op     |   11 allocs/op    |
+| log15               | 5181 ns/op |    1592 B/op    |   26 allocs/op    |
 
 ## Caveats
 
 ### Field duplication
 
-Note that zerolog does no de-duplication of fields. Using the same key multiple times creates multiple keys in final JSON:
+Note that zerolog does no de-duplication of fields by default. Using the same key multiple times creates multiple keys in final JSON:
 
 ```go
 logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
@@ -764,6 +766,33 @@ logger.Info().
 ```
 
 In this case, many consumers will take the last value, but this is not guaranteed; check yours if in doubt.
+If you need de-duplication of fields, use the DeDup method. This is an expensive method so it is recommended to avoid it if able.
+Note that if the DeDuplication fails, it will fall back to printing all fields without deduplication.
+
+```go
+logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+logger.Info().
+       Timestamp().
+       DeDup().
+       Msg("dup")
+// Output: {"level":"info","time":1494567715,"time":1494567715,"message":"dup"}
+```
+
+You can also use the DeDup method when when creating a child logger which is preferred as you only pay for the performance hit once.
+
+```go
+logger := zerolog.New(os.Stderr).With().Str("foo", "bar").Timestamp().Logger()
+logger.Info().Msg("hello world")
+// Output: {"level":"info","time":1494567715,"foo":"bar","message":"hello world"}
+
+sublogger := logger.With().Str("foo", "baz").DeDup().Logger()
+sublogger.Info().Msg("hello world")
+// Output: {"level":"info","time":1494567715,"foo":"bar","foo":"baz","message":"hello world"}
+
+subloggerDeDup := logger.With().Str("foo", "baz").DeDup().Logger()
+subloggerDeDup.Info().Msg("hello world")
+// Output: {"level":"info","time":1494567715,"foo":"baz","message":"hello world"}
+```
 
 ### Concurrency safety
 

--- a/README.md
+++ b/README.md
@@ -795,6 +795,9 @@ subloggerDeDup.Info().Msg("hello world")
 // Output: {"level":"info","time":1494567715,"foo":"baz","message":"hello world"}
 ```
 
+Usage of DeDup method is generally recommended for performance as it only scans root level keys to ensure there are no duplicates.
+If scanning of deeper keys is required for deduplication, use DeDupDeep.
+
 ### Concurrency safety
 
 Be careful when calling UpdateContext. It is not concurrency safe. Use the With method to create a child logger:

--- a/README.md
+++ b/README.md
@@ -670,6 +670,7 @@ Some settings can be changed and will be applied to all loggers:
 - `RawJSON`: Adds a field with an already encoded JSON (`[]byte`)
 - `Hex`: Adds a field with value formatted as a hexadecimal string (`[]byte`)
 - `Interface`: Uses reflection to marshal the type.
+- `Any`: Wrapper for `Interface`.
 
 Most fields are also available in the slice format (`Strs` for `[]string`, `Errs` for `[]error` etc.)
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -71,6 +71,54 @@ func BenchmarkContextAppend(b *testing.B) {
 	})
 }
 
+func BenchmarkContextAppendWithDeDup(b *testing.B) {
+	logger := New(io.Discard).With().
+		Str("foo", "bar").
+		Logger()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.With().Str("foo", "baz").DeDup()
+		}
+	})
+}
+
+func BenchmarkContextAppendWithDeDupDeep(b *testing.B) {
+	logger := New(io.Discard).With().
+		Str("foo", "bar").
+		Logger()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.With().Str("foo", "baz").DeDupDeep()
+		}
+	})
+}
+
+func BenchmarkLogWithDeDup(b *testing.B) {
+	logger := New(io.Discard).With().
+		Str("foo", "bar").
+		Logger()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info().Str("foo", "baz").DeDup().Msg(fakeMessage)
+		}
+	})
+}
+
+func BenchmarkLogWithDeDupDeep(b *testing.B) {
+	logger := New(io.Discard).With().
+		Str("foo", "bar").
+		Logger()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info().Str("foo", "baz").DeDupDeep().Msg(fakeMessage)
+		}
+	})
+}
+
 func BenchmarkLogFields(b *testing.B) {
 	logger := New(io.Discard)
 	b.ResetTimer()

--- a/context.go
+++ b/context.go
@@ -483,7 +483,6 @@ func (c Context) MACAddr(key string, ha net.HardwareAddr) Context {
 // DeDup removes duplicate fields and keeps last added field in context.
 //
 // Caution: This is an expensive operation.
-// If it fails, it will revert back to the original data with potentially duplicated fields
 func (c Context) DeDup() Context {
 	if len(c.l.context) <= 1 {
 		return c
@@ -496,12 +495,12 @@ func (c Context) DeDup() Context {
 	for i = 1; i < len(c.l.context); i++ {
 		if c.l.context[i] == ':' {
 			colon = i
-			if c.l.context[i+1] == '{' {
+			if c.l.context[i+1] == '{' || c.l.context[i+1] == '[' {
 				depth := 1
 				for i = i + 2; depth > 0; i++ {
-					if c.l.context[i] == '{' {
+					if c.l.context[i] == '{' || c.l.context[i] == '[' {
 						depth++
-					} else if c.l.context[i] == '}' {
+					} else if c.l.context[i] == '}' || c.l.context[i] == ']' {
 						depth--
 					}
 				}
@@ -513,7 +512,8 @@ func (c Context) DeDup() Context {
 			start = i + 1
 		}
 	}
-	if c.l.context[i-2] != '}' {
+	if c.l.context[i-2] == '}' || c.l.context[i-2] == ']' {
+	} else {
 		values[string(c.l.context[start:colon])] = c.l.context[colon+1:]
 	}
 

--- a/event.go
+++ b/event.go
@@ -833,7 +833,6 @@ func (e *Event) MACAddr(key string, ha net.HardwareAddr) *Event {
 // DeDup removes duplicate fields and keeps last added field in context.
 //
 // Caution: This is an expensive operation.
-// If it fails, it will revert back to the original data with potentially duplicated fields
 func (e *Event) DeDup() *Event {
 	if len(e.buf) <= 1 {
 		return e
@@ -846,12 +845,12 @@ func (e *Event) DeDup() *Event {
 	for i = 1; i < len(e.buf); i++ {
 		if e.buf[i] == ':' {
 			colon = i
-			if e.buf[i+1] == '{' {
+			if e.buf[i+1] == '{' || e.buf[i+1] == '[' {
 				depth := 1
 				for i = i + 2; depth > 0; i++ {
-					if e.buf[i] == '{' {
+					if e.buf[i] == '{' || e.buf[i] == '[' {
 						depth++
-					} else if e.buf[i] == '}' {
+					} else if e.buf[i] == '}' || e.buf[i] == ']' {
 						depth--
 					}
 				}
@@ -863,7 +862,8 @@ func (e *Event) DeDup() *Event {
 			start = i + 1
 		}
 	}
-	if e.buf[i-2] != '}' {
+	if e.buf[i-2] == '}' || e.buf[i-2] == ']' {
+	} else {
 		values[string(e.buf[start:colon])] = e.buf[colon+1:]
 	}
 

--- a/log_example_test.go
+++ b/log_example_test.go
@@ -1,3 +1,4 @@
+//go:build !binary_log
 // +build !binary_log
 
 package zerolog_test
@@ -559,4 +560,53 @@ func ExampleContext_Fields_slice() {
 	log.Log().Msg("hello world")
 
 	// Output: {"foo":"bar","bar":"baz","n":1,"message":"hello world"}
+}
+
+func ExampleContext_DeDup() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Str("foo", "bar").
+		Str("foo", "baz").
+		DeDup().
+		Logger()
+
+	log.Info().Msg("hello world")
+
+	// Output: {"level":"info","foo":"baz","message":"hello world"}
+}
+
+func ExampleContext_DeDup_unused() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Str("foo", "bar").
+		Str("foo", "baz").
+		Logger()
+
+	log.Info().Msg("hello world")
+
+	// Output: {"level":"info","foo":"bar","foo":"baz","message":"hello world"}
+}
+
+func ExampleContext_DeDup_empty() {
+	log := zerolog.New(os.Stdout).
+		With().
+		DeDup().
+		Logger()
+
+	log.Info().Msg("hello world")
+
+	// Output: {"level":"info","message":"hello world"}
+}
+
+func ExampleContext_DeDup_event() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Str("foo", "bar").
+		Str("foo", "baz").
+		DeDup().
+		Logger()
+
+	log.Info().Str("foo", "bam").DeDup().Msg("hello world")
+
+	// Output: {"foo":"bam","level":"info","message":"hello world"}
 }

--- a/log_example_test.go
+++ b/log_example_test.go
@@ -4,11 +4,13 @@
 package zerolog_test
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	stdlog "log"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -599,7 +601,8 @@ func ExampleContext_DeDup_empty() {
 }
 
 func ExampleContext_DeDup_dictionary() {
-	log := zerolog.New(os.Stdout).
+	var buf bytes.Buffer
+	log := zerolog.New(&buf).
 		With().
 		Dict("dict", zerolog.Dict().
 			Str("foo", "bar").
@@ -614,7 +617,53 @@ func ExampleContext_DeDup_dictionary() {
 
 	log.Info().Msg("hello world")
 
-	// Output: {"level":"info","dict":{"foo":"baz","n":2},"message":"hello world"}
+	output := strings.TrimSpace(buf.String())
+	expectedFormat1 := `{"level":"info","dict":{"foo":"baz","n":2},"message":"hello world"}`
+	expectedFormat2 := `{"dict":{"foo":"bam","n":3},"level":"info","message":"hello world"}`
+
+	if output != expectedFormat1 && output != expectedFormat2 {
+		fmt.Printf("Output did not match either expected format.\n  Got:      %s\n  Expected: %s\n  or:       %s",
+			output, expectedFormat1, expectedFormat2)
+	}
+
+	// Output:
+}
+
+func ExampleContext_DeDup_array() {
+	var buf bytes.Buffer
+	log := zerolog.New(&buf).
+		With().
+		Array("array", zerolog.Arr().
+			Str("bar").
+			Int(1).
+			Dict(zerolog.Dict().
+				Str("foo", "bar").
+				Int("n", 1),
+			),
+		).
+		Array("array", zerolog.Arr().
+			Str("baz").
+			Int(1).
+			Dict(zerolog.Dict().
+				Str("foo", "baz").
+				Int("n", 2),
+			),
+		).
+		DeDupDeep().
+		Logger()
+
+	log.Info().Msg("hello world")
+
+	output := strings.TrimSpace(buf.String())
+	expectedFormat1 := `{"array":["baz",1,{"foo":"baz","n":2}],"level":"info","message":"hello world"}`
+	expectedFormat2 := `{"level":"info","array":["baz",1,{"foo":"baz","n":2}],"message":"hello world"}`
+
+	if output != expectedFormat1 && output != expectedFormat2 {
+		fmt.Printf("Output did not match either expected format.\n  Got:      %s\n  Expected: %s\n  or:       %s",
+			output, expectedFormat1, expectedFormat2)
+	}
+
+	// Output:
 }
 
 func ExampleEvent_DeDup() {
@@ -651,7 +700,8 @@ func ExampleEvent_DeDup_empty() {
 }
 
 func ExampleEvent_DeDup_dictionary() {
-	log := zerolog.New(os.Stdout).
+	var buf bytes.Buffer
+	log := zerolog.New(&buf).
 		With().
 		Dict("dict", zerolog.Dict().
 			Str("foo", "bar").
@@ -671,7 +721,55 @@ func ExampleEvent_DeDup_dictionary() {
 		DeDup().
 		Msg("hello world")
 
-	// Output: {"level":"info","dict":{"foo":"bam","n":3},"message":"hello world"}
+	output := strings.TrimSpace(buf.String())
+	expectedFormat1 := `{"level":"info","dict":{"foo":"bam","n":3},"message":"hello world"}`
+	expectedFormat2 := `{"dict":{"foo":"bam","n":3},"level":"info","message":"hello world"}`
+
+	if output != expectedFormat1 && output != expectedFormat2 {
+		fmt.Printf("Output did not match either expected format.\n  Got:      %s\n  Expected: %s\n  or:       %s",
+			output, expectedFormat1, expectedFormat2)
+	}
+
+	// Output:
+}
+
+func ExampleEvent_DeDup_array() {
+	var buf bytes.Buffer
+	log := zerolog.New(&buf).
+		With().
+		Array("array", zerolog.Arr().
+			Str("bar").
+			Int(1).
+			Dict(zerolog.Dict().
+				Str("foo", "bar").
+				Int("n", 1),
+			),
+		).
+		DeDupDeep().
+		Logger()
+
+	log.Info().
+		Array("array", zerolog.Arr().
+			Str("baz").
+			Int(1).
+			Dict(zerolog.Dict().
+				Str("foo", "baz").
+				Int("n", 2),
+			),
+		).
+		DeDupDeep().
+		Msg("hello world")
+
+	output := strings.TrimSpace(buf.String())
+	expectedFormat1 := `{"array":["baz",1,{"foo":"baz","n":2}],"level":"info","message":"hello world"}`
+	expectedFormat2 := `{"level":"info","array":["baz",1,{"foo":"baz","n":2}],"message":"hello world"}`
+
+	if output != expectedFormat1 && output != expectedFormat2 {
+		fmt.Printf("Output did not match either expected format.\n  Got:      %s\n  Expected: %s\n  or:       %s",
+			output, expectedFormat1, expectedFormat2)
+	}
+
+	// Output:
 }
 
 func ExampleContext_DeDupDeep() {
@@ -711,7 +809,8 @@ func ExampleContext_DeDupDeep_empty() {
 }
 
 func ExampleContext_DeDupDeep_dictionary() {
-	log := zerolog.New(os.Stdout).
+	var buf bytes.Buffer
+	log := zerolog.New(&buf).
 		With().
 		Dict("dict", zerolog.Dict().
 			Str("foo", "bar").
@@ -726,7 +825,53 @@ func ExampleContext_DeDupDeep_dictionary() {
 
 	log.Info().Msg("hello world")
 
-	// Output: {"level":"info","dict":{"foo":"baz","n":2},"message":"hello world"}
+	output := strings.TrimSpace(buf.String())
+	expectedFormat1 := `{"level":"info","dict":{"foo":"baz","n":2},"message":"hello world"}`
+	expectedFormat2 := `{"dict":{"foo":"bam","n":3},"level":"info","message":"hello world"}`
+
+	if output != expectedFormat1 && output != expectedFormat2 {
+		fmt.Printf("Output did not match either expected format.\n  Got:      %s\n  Expected: %s\n  or:       %s",
+			output, expectedFormat1, expectedFormat2)
+	}
+
+	// Output:
+}
+
+func ExampleContext_DeDupDeep_array() {
+	var buf bytes.Buffer
+	log := zerolog.New(&buf).
+		With().
+		Array("array", zerolog.Arr().
+			Str("bar").
+			Int(1).
+			Dict(zerolog.Dict().
+				Str("foo", "bar").
+				Int("n", 1),
+			),
+		).
+		Array("array", zerolog.Arr().
+			Str("baz").
+			Int(1).
+			Dict(zerolog.Dict().
+				Str("foo", "baz").
+				Int("n", 2),
+			),
+		).
+		DeDupDeep().
+		Logger()
+
+	log.Info().Msg("hello world")
+
+	output := strings.TrimSpace(buf.String())
+	expectedFormat1 := `{"array":["baz",1,{"foo":"baz","n":2}],"level":"info","message":"hello world"}`
+	expectedFormat2 := `{"level":"info","array":["baz",1,{"foo":"baz","n":2}],"message":"hello world"}`
+
+	if output != expectedFormat1 && output != expectedFormat2 {
+		fmt.Printf("Output did not match either expected format.\n  Got:      %s\n  Expected: %s\n  or:       %s",
+			output, expectedFormat1, expectedFormat2)
+	}
+
+	// Output:
 }
 
 func ExampleEvent_DeDupDeep() {
@@ -763,7 +908,8 @@ func ExampleEvent_DeDupDeep_empty() {
 }
 
 func ExampleEvent_DeDupDeep_dictionary() {
-	log := zerolog.New(os.Stdout).
+	var buf bytes.Buffer
+	log := zerolog.New(&buf).
 		With().
 		Dict("dict", zerolog.Dict().
 			Str("foo", "bar").
@@ -783,5 +929,52 @@ func ExampleEvent_DeDupDeep_dictionary() {
 		DeDupDeep().
 		Msg("hello world")
 
-	// Output: {"dict":{"foo":"bam","n":3},"level":"info","message":"hello world"}
+	output := strings.TrimSpace(buf.String())
+	expectedFormat1 := `{"level":"info","dict":{"foo":"bam","n":3},"message":"hello world"}`
+	expectedFormat2 := `{"dict":{"foo":"bam","n":3},"level":"info","message":"hello world"}`
+
+	if output != expectedFormat1 && output != expectedFormat2 {
+		fmt.Printf("Output did not match either expected format.\n  Got:      %s\n  Expected: %s\n  or:       %s",
+			output, expectedFormat1, expectedFormat2)
+	}
+
+	// Output:
+}
+func ExampleEvent_DeDupDeep_array() {
+	var buf bytes.Buffer
+	log := zerolog.New(&buf).
+		With().
+		Array("array", zerolog.Arr().
+			Str("bar").
+			Int(1).
+			Dict(zerolog.Dict().
+				Str("foo", "bar").
+				Int("n", 1),
+			),
+		).
+		DeDupDeep().
+		Logger()
+
+	log.Info().
+		Array("array", zerolog.Arr().
+			Str("baz").
+			Int(1).
+			Dict(zerolog.Dict().
+				Str("foo", "baz").
+				Int("n", 2),
+			),
+		).
+		DeDupDeep().
+		Msg("hello world")
+
+	output := strings.TrimSpace(buf.String())
+	expectedFormat1 := `{"array":["baz",1,{"foo":"baz","n":2}],"level":"info","message":"hello world"}`
+	expectedFormat2 := `{"level":"info","array":["baz",1,{"foo":"baz","n":2}],"message":"hello world"}`
+
+	if output != expectedFormat1 && output != expectedFormat2 {
+		fmt.Printf("Output did not match either expected format.\n  Got:      %s\n  Expected: %s\n  or:       %s",
+			output, expectedFormat1, expectedFormat2)
+	}
+
+	// Output:
 }

--- a/log_example_test.go
+++ b/log_example_test.go
@@ -598,15 +598,190 @@ func ExampleContext_DeDup_empty() {
 	// Output: {"level":"info","message":"hello world"}
 }
 
-func ExampleContext_DeDup_event() {
+func ExampleContext_DeDup_dictionary() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Dict("dict", zerolog.Dict().
+			Str("foo", "bar").
+			Int("n", 1),
+		).
+		Dict("dict", zerolog.Dict().
+			Str("foo", "baz").
+			Int("n", 2),
+		).
+		DeDup().
+		Logger()
+
+	log.Info().Msg("hello world")
+
+	// Output: {"level":"info","dict":{"foo":"baz","n":2},"message":"hello world"}
+}
+
+func ExampleEvent_DeDup() {
 	log := zerolog.New(os.Stdout).
 		With().
 		Str("foo", "bar").
 		Str("foo", "baz").
-		DeDup().
 		Logger()
 
 	log.Info().Str("foo", "bam").DeDup().Msg("hello world")
 
+	// Output: {"level":"info","foo":"bam","message":"hello world"}
+}
+
+func ExampleEvent_DeDup_unused() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Str("foo", "bar").
+		Logger()
+
+	log.Info().Str("foo", "baz").Msg("hello world")
+
+	// Output: {"level":"info","foo":"bar","foo":"baz","message":"hello world"}
+}
+
+func ExampleEvent_DeDup_empty() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Logger()
+
+	log.Info().DeDup().Msg("hello world")
+
+	// Output: {"level":"info","message":"hello world"}
+}
+
+func ExampleEvent_DeDup_dictionary() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Dict("dict", zerolog.Dict().
+			Str("foo", "bar").
+			Int("n", 1),
+		).
+		Dict("dict", zerolog.Dict().
+			Str("foo", "baz").
+			Int("n", 2),
+		).
+		Logger()
+
+	log.Info().
+		Dict("dict", zerolog.Dict().
+			Str("foo", "bam").
+			Int("n", 3),
+		).
+		DeDup().
+		Msg("hello world")
+
+	// Output: {"level":"info","dict":{"foo":"bam","n":3},"message":"hello world"}
+}
+
+func ExampleContext_DeDupDeep() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Str("foo", "bar").
+		Str("foo", "baz").
+		DeDupDeep().
+		Logger()
+
+	log.Info().Msg("hello world")
+
+	// Output: {"level":"info","foo":"baz","message":"hello world"}
+}
+
+func ExampleContext_DeDupDeep_unused() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Str("foo", "bar").
+		Str("foo", "baz").
+		Logger()
+
+	log.Info().Msg("hello world")
+
+	// Output: {"level":"info","foo":"bar","foo":"baz","message":"hello world"}
+}
+
+func ExampleContext_DeDupDeep_empty() {
+	log := zerolog.New(os.Stdout).
+		With().
+		DeDupDeep().
+		Logger()
+
+	log.Info().Msg("hello world")
+
+	// Output: {"level":"info","message":"hello world"}
+}
+
+func ExampleContext_DeDupDeep_dictionary() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Dict("dict", zerolog.Dict().
+			Str("foo", "bar").
+			Int("n", 1),
+		).
+		Dict("dict", zerolog.Dict().
+			Str("foo", "baz").
+			Int("n", 2),
+		).
+		DeDupDeep().
+		Logger()
+
+	log.Info().Msg("hello world")
+
+	// Output: {"level":"info","dict":{"foo":"baz","n":2},"message":"hello world"}
+}
+
+func ExampleEvent_DeDupDeep() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Str("foo", "bar").
+		Str("foo", "baz").
+		Logger()
+
+	log.Info().Str("foo", "bam").DeDupDeep().Msg("hello world")
+
 	// Output: {"foo":"bam","level":"info","message":"hello world"}
+}
+
+func ExampleEvent_DeDupDeep_unused() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Str("foo", "bar").
+		Logger()
+
+	log.Info().Str("foo", "baz").Msg("hello world")
+
+	// Output: {"level":"info","foo":"bar","foo":"baz","message":"hello world"}
+}
+
+func ExampleEvent_DeDupDeep_empty() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Logger()
+
+	log.Info().DeDupDeep().Msg("hello world")
+
+	// Output: {"level":"info","message":"hello world"}
+}
+
+func ExampleEvent_DeDupDeep_dictionary() {
+	log := zerolog.New(os.Stdout).
+		With().
+		Dict("dict", zerolog.Dict().
+			Str("foo", "bar").
+			Int("n", 1),
+		).
+		Dict("dict", zerolog.Dict().
+			Str("foo", "baz").
+			Int("n", 2),
+		).
+		Logger()
+
+	log.Info().
+		Dict("dict", zerolog.Dict().
+			Str("foo", "bam").
+			Int("n", 3),
+		).
+		DeDupDeep().
+		Msg("hello world")
+
+	// Output: {"dict":{"foo":"bam","n":3},"level":"info","message":"hello world"}
 }


### PR DESCRIPTION
Bug Fix:
- console_test.go/Write_caller_field will fail on Windows machines so I modified the test to allow it to pass in a Windows or Linux environment.

New Features:
- Add DeDup method to Events and Context that scans all root level keys and only keeps the newest
- Add DeDupDeep method that works just like DeDup but scans all keys and remaps them to remove duplicates

Background:
As noted in the original readme zerolog does not natively support deduplication of keys placed within the structured logs. I ran into an issue where my log ingestion tool could not handle duplicated keys.
Currently I pass around logging instances and create child loggers where I utilize the key `app` to determine what sub application that data is coming from. My key motivation was adding the DeDup method for Context so that on creation of a child logger I can remove that and any other duplicate fields. However, I also added DeDup to Events for extending the capability.
My attempt was also to make the DeDup method performant and opt in so that it does not impact zerolog's goal for performance unless invoked. 