### PR TITLE
BasicSampler(0), RandomSampler(0), and BurstSampler(0) must not panic but discard logs

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -47,6 +47,9 @@ type BasicSampler struct {
 // Sample implements the Sampler interface.
 func (s *BasicSampler) Sample(lvl Level) bool {
 	n := s.N
+	if n == 0 {
+		return false
+	}
 	if n == 1 {
 		return true
 	}

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -29,6 +29,13 @@ var samplers = []struct {
 		100, 20, 20,
 	},
 	{
+		"BasicSampler_0",
+		func() Sampler {
+			return &BasicSampler{N: 0}
+		},
+		100, 0, 0,
+	},
+	{
 		"RandomSampler",
 		func() Sampler {
 			return RandomSampler(5)
@@ -36,11 +43,25 @@ var samplers = []struct {
 		100, 10, 30,
 	},
 	{
+		"RandomSampler_0",
+		func() Sampler {
+			return RandomSampler(0)
+		},
+		100, 0, 0,
+	},
+	{
 		"BurstSampler",
 		func() Sampler {
 			return &BurstSampler{Burst: 20, Period: time.Second}
 		},
 		100, 20, 20,
+	},
+	{
+		"BurstSampler_0",
+		func() Sampler {
+			return &BurstSampler{Burst: 0, Period: time.Second}
+		},
+		100, 0, 0,
 	},
 	{
 		"BurstSamplerNext",


### PR DESCRIPTION
When in use, zerolog.BasicSampler{N: 0} panics and the whole app crashes. But for other samplers, zero means disabling all logs. It may seem confusing that writing every zero-th line is writing nothing, but it's helpful to maintain consistency with other samplers.
So my suggestion is to remove the panic, and cover this corner case with tests.