### PR TITLE
allow more time formats to prettylog command

### DIFF
--- a/cmd/prettylog/prettylog.go
+++ b/cmd/prettylog/prettylog.go
@@ -7,10 +7,40 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
 )
+
+var timeFormats map[string]string = map[string]string{
+	"default":     time.Kitchen,
+	"ansic":       time.ANSIC,
+	"unix":        time.UnixDate,
+	"rfc822":      time.RFC822,
+	"rfc822z":     time.RFC822Z,
+	"rfc850":      time.RFC850,
+	"rfc1123":     time.RFC1123,
+	"rfc1123z":    time.RFC1123Z,
+	"rfc3339":     time.RFC3339,
+	"rfc3339nano": time.RFC3339Nano,
+	"stamp":       time.Stamp,
+	"stampmilli":  time.StampMilli,
+	"datetime":    time.DateTime,
+	"timeonly":    time.TimeOnly,
+	"full":        time.RFC1123,
+}
+
+func allowedTimeFormats() string {
+	formats := make([]string, 0, len(timeFormats))
+	for k := range timeFormats {
+		formats = append(formats, k)
+	}
+	sort.Strings(formats)
+
+	return strings.Join(formats, ", ")
+}
 
 func isInputFromPipe() bool {
 	fileInfo, _ := os.Stdin.Stat()
@@ -34,27 +64,26 @@ func processInput(reader io.Reader, writer io.Writer) error {
 	return scanner.Err()
 }
 
-func main() {
-	timeFormats := map[string]string{
-		"default": time.Kitchen,
-		"full":    time.RFC1123,
+func getTimeFormat(flagValue string) string {
+	format, ok := timeFormats[flagValue]
+	if !ok {
+		return flagValue
 	}
 
+	return format
+}
+
+func main() {
 	timeFormatFlag := flag.String(
 		"time-format",
 		"default",
-		"Time format, either 'default' or 'full'",
+		"Time format, one of: "+allowedTimeFormats()+" or a custom golang time format",
 	)
 
 	flag.Parse()
 
-	timeFormat, ok := timeFormats[*timeFormatFlag]
-	if !ok {
-		panic("Invalid time-format provided")
-	}
-
 	writer := zerolog.NewConsoleWriter()
-	writer.TimeFormat = timeFormat
+	writer.TimeFormat = getTimeFormat(*timeFormatFlag)
 
 	if isInputFromPipe() {
 		_ = processInput(os.Stdin, writer)


### PR DESCRIPTION
# Thank You!

First, I want to express my gratitude to the authors of the zerolog library—it’s an amazing tool that I truly appreciate!

# Summary

This PR extends the functionality of the prettylog command by enabling the use of a wider range of supported time formats. The current limitation to Kitchen and RFC1123 formats can be restrictive in certain scenarios, as I’ve experienced.

# Proposed Changes
1. Add Support for More Predefined Formats
   Include the following additional time formats:
   - ANSIC
   - DateTime
   - RFC1123
   - RFC1123Z
   - RFC3339
   - RFC3339Nano
   - RFC822
   - RFC822Z
   - RFC850
   - Stamp
   - StampMilli
   - TimeOnly
   - Unix
2. Enable Custom Time Formats
   Allow users to specify their own custom Go time format strings, offering maximum flexibility.
3. Maintain Backward Compatibility
   Retain the existing `default` and `full` formats to ensure seamless upgrades for current users.
   
---
This update expands the functionality of prettylog while respecting the existing defaults, ensuring a smooth transition for current users. I believe this enhancement will benefit a wide range of use cases and make the tool even more versatile.