### PR TITLE
remove unnecessary nil checks before calling len() on slices

### DIFF
--- a/console.go
+++ b/console.go
@@ -283,7 +283,7 @@ func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer
 func (w ConsoleWriter) writePart(buf *bytes.Buffer, evt map[string]interface{}, p string) {
 	var f Formatter
 
-	if w.PartsExclude != nil && len(w.PartsExclude) > 0 {
+	if len(w.PartsExclude) > 0 {
 		for _, exclude := range w.PartsExclude {
 			if exclude == p {
 				return

--- a/log.go
+++ b/log.go
@@ -494,7 +494,7 @@ func (l *Logger) newEvent(level Level, done func(string)) *Event {
 	if level != NoLevel && LevelFieldName != "" {
 		e.Str(LevelFieldName, LevelFieldMarshalFunc(level))
 	}
-	if l.context != nil && len(l.context) > 1 {
+	if len(l.context) > 1 {
 		e.buf = enc.AppendObjectData(e.buf, l.context)
 	}
 	if l.stack {


### PR DESCRIPTION
this PR removes unnecessary nil checks before calling `len()` on slices.,
```
var slice []byte // equal to nil, default value for a slice
if slice != nil && len(slice) > 1 {}
// is the same as
if len(slice) > 1 {}
```
because `len(slice)` where slice == nil is always equal to 0,

`staticcheck` will highlight this optimization with the following message:
```
log.go:497:5: should omit nil check; len() for []byte is defined as zero (S1009)
```