### PR TITLE
Improving Linux accessibility #692 | Update default timestamp color for linux accessibility 

### DIFF
--- a/console.go
+++ b/console.go
@@ -101,9 +101,9 @@ type ConsoleWriter struct {
 // NewConsoleWriter creates and initializes a new ConsoleWriter.
 func NewConsoleWriter(options ...func(w *ConsoleWriter)) ConsoleWriter {
 	w := ConsoleWriter{
-		Out:          os.Stdout,
-		TimeFormat:   consoleDefaultTimeFormat,
-		PartsOrder:   consoleDefaultPartsOrder(),
+		Out:        os.Stdout,
+		TimeFormat: consoleDefaultTimeFormat,
+		PartsOrder: consoleDefaultPartsOrder(),
 	}
 
 	for _, opt := range options {
@@ -449,7 +449,7 @@ func consoleDefaultFormatTimestamp(timeFormat string, location *time.Location, n
 				t = ts.In(location).Format(timeFormat)
 			}
 		}
-		return colorize(t, colorDarkGray, noColor)
+		return colorize(t, colorCyan, noColor)
 	}
 }
 


### PR DESCRIPTION
Original Issue: https://github.com/rs/zerolog/issues/692
Suggested change of default color + fmt file.