### PR TITLE
fix: reset condition in burst sampler (#711)

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -90,7 +90,7 @@ func (s *BurstSampler) inc() uint32 {
 	now := TimestampFunc().UnixNano()
 	resetAt := atomic.LoadInt64(&s.resetAt)
 	var c uint32
-	if now > resetAt {
+	if now >= resetAt {
 		c = 1
 		atomic.StoreUint32(&s.counter, c)
 		newResetAt := now + s.Period.Nanoseconds()


### PR DESCRIPTION
This PR solves the bug reported in https://github.com/rs/zerolog/issues/711.

I also added a simple unit test that uses mocked time to cover this feature.