### PR TITLE
Expose the internal function cbor.DecodeIfBinaryToBytes()

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -55,7 +55,6 @@ type encoder interface {
 	AppendUints8(dst []byte, vals []uint8) []byte
 }
 
-
 func CBORDecodeIfBinaryToBytes(in []byte) []byte {
 	return cbor.DecodeIfBinaryToBytes(in)
 }

--- a/encoder.go
+++ b/encoder.go
@@ -3,6 +3,7 @@ package zerolog
 import (
 	"net"
 	"time"
+	"github.com/rs/zerolog/internal/cbor"
 )
 
 type encoder interface {

--- a/encoder.go
+++ b/encoder.go
@@ -54,3 +54,8 @@ type encoder interface {
 	AppendUints64(dst []byte, vals []uint64) []byte
 	AppendUints8(dst []byte, vals []uint8) []byte
 }
+
+
+func CBORDecodeIfBinaryToBytes(in []byte) []byte {
+	return cbor.DecodeIfBinaryToBytes(in)
+}


### PR DESCRIPTION
cbor.DecodeIfBinaryToBytes() is a useful function, but it's inside zerolog/internal and therefore not accessible directly. And it's only implicitly available when the `binary_log` build tag is enabled. I'd like to be able to use it in downstream log collectors, but currently the only approach which works is to cut-and-paste the code into a local module.  Adding a publically-visible wrapper would make this easy.

Thanks!