### PR TITLE
Add ExitFunc for FatalLevel log messages

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -3,7 +3,6 @@ package zerolog
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -121,9 +120,6 @@ var (
 	// be thread safe and non-blocking.
 	ErrorHandler func(err error)
 
-	// ExitFunc is the fucntion called to exit the application, defaults to `os.Exit()`
-	ExitFunc exitFunc = os.Exit
-
 	// DefaultContextLogger is returned from Ctx() if there is no logger associated
 	// with the context.
 	DefaultContextLogger *Logger
@@ -166,8 +162,6 @@ var (
 	gLevel          = new(int32)
 	disableSampling = new(int32)
 )
-
-type exitFunc func(int)
 
 // SetGlobalLevel sets the global override for log level. If this
 // values is raised, all Loggers will use at least this value.

--- a/globals.go
+++ b/globals.go
@@ -3,6 +3,7 @@ package zerolog
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -120,6 +121,9 @@ var (
 	// be thread safe and non-blocking.
 	ErrorHandler func(err error)
 
+	// ExitFunc is the fucntion called to exit the application, defaults to `os.Exit()`
+	ExitFunc exitFunc = os.Exit
+
 	// DefaultContextLogger is returned from Ctx() if there is no logger associated
 	// with the context.
 	DefaultContextLogger *Logger
@@ -162,6 +166,8 @@ var (
 	gLevel          = new(int32)
 	disableSampling = new(int32)
 )
+
+type exitFunc func(int)
 
 // SetGlobalLevel sets the global override for log level. If this
 // values is raised, all Loggers will use at least this value.

--- a/log.go
+++ b/log.go
@@ -382,18 +382,22 @@ func (l *Logger) Err(err error) *Event {
 	return l.Info()
 }
 
-// Fatal starts a new message with fatal level. The os.Exit(1) function
-// is called by the Msg method, which terminates the program immediately.
+// Fatal starts a new message with fatal level. The ExitFunc(1) function
+// (os.Exit by default) is called by the Msg method, which terminates the 
+// program immediately.
 //
 // You must call Msg on the returned event in order to send the event.
 func (l *Logger) Fatal() *Event {
 	return l.newEvent(FatalLevel, func(msg string) {
 		if closer, ok := l.w.(io.Closer); ok {
 			// Close the writer to flush any buffered message. Otherwise the message
-			// will be lost as os.Exit() terminates the program immediately.
+			// will be lost as ExitFunc() (os.Exit by default) terminates the program immediately.
 			closer.Close()
 		}
-		os.Exit(1)
+		if ExitFunc == nil {
+			ExitFunc = os.Exit
+		}
+		ExitFunc(1)
 	})
 }
 

--- a/log_test.go
+++ b/log_test.go
@@ -115,8 +115,7 @@ func TestFatal(t *testing.T) {
 
 	t.Run("should not exit", func(t *testing.T) {
 		out := &bytes.Buffer{}
-		ExitFunc = func(code int) {} // dummy exit func
-		log := New(out)
+		log := New(out).ExitFunc(func(_ int) {})
 		log.Fatal().Msg("")
 		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"fatal"}`+"\n"; got != want {
 			t.Errorf("invalid log output:\n got:  %v\nwant: %v", got, want)


### PR DESCRIPTION
resolves rs/zerolog#397

inspiration from logrus...

This change is primarily motivated by the need to facilitate easier testing in applications that frequently use `Fatal()`. Additionally, it could benefit scenarios where applications require custom shutdown procedures for cleanup or other special handling but still choose to rely on zerolog to perform process termination.