### PR TITLE
feat: allow to use a `LogArrayMarshaler` as error stacks

### DIFF
--- a/event.go
+++ b/event.go
@@ -396,6 +396,8 @@ func (e *Event) Err(err error) *Event {
 		case nil:
 		case LogObjectMarshaler:
 			e.Object(ErrorStackFieldName, m)
+		case LogArrayMarshaler:
+			e.Array(ErrorStackFieldName, m)
 		case error:
 			if m != nil && !isNilValue(m) {
 				e.Str(ErrorStackFieldName, m.Error())


### PR DESCRIPTION
This will allow user to marshal error stack like this, without using json marshaler:

```
{
  "error": "a: raw error",
  "stack": [
    {
      "function": "main.a",
      "file": "./main.go",
      "lino": 23
    },
    {
      "function": "main.main",
      "file": "./main.go",
      "lino": 19
    },
    {
      "function": "runtime.main",
      "file": "runtime/proc.go",
      "lino": 283
    },
    {
      "function": "runtime.goexit",
      "file": "runtime/asm_amd64.s",
      "lino": 1700
    }
  ]
}
```