### PR TITLE
Add slog interface implementation to Related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ with zerolog library is [CSD](https://github.com/toravir/csd/).
 * [grpc-zerolog](https://github.com/cheapRoc/grpc-zerolog): Implementation of `grpclog.LoggerV2` interface using `zerolog`
 * [overlog](https://github.com/Trendyol/overlog): Implementation of `Mapped Diagnostic Context` interface using `zerolog`
 * [zerologr](https://github.com/go-logr/zerologr): Implementation of `logr.LogSink` interface using `zerolog`
+* [logze](https://github.com/maxbolgarin/logze): Implementation of `log/slog` interface using `zerolog`
 
 ## Benchmarks
 


### PR DESCRIPTION
I have created [logze](https://github.com/maxbolgarin/logze) — an slog interface implementation built on top of zerolog. It combines zerolog's high performance (with benchmarks included in the repository) with the standard slog interface that many Go developers are familiar with. I believe this would be valuable for the zerolog community.

I have successfully deployed logze across all my projects, and my team at our IT company uses a private fork (maintained for security compliance purposes). The library is thoroughly tested, stable, and provides zerolog's powerful features through an intuitive interface. It includes comprehensive documentation with a detailed README and complete godoc coverage.
I would be honored if you would consider adding this project to your README as a community resource.

Thank you for creating and maintaining zerolog!