### PR TITLE
fix: Context.EmbedObject returns a broken json when object is empty

### DIFF
--- a/context.go
+++ b/context.go
@@ -68,7 +68,9 @@ func (c Context) Object(key string, obj LogObjectMarshaler) Context {
 func (c Context) EmbedObject(obj LogObjectMarshaler) Context {
 	e := newEvent(LevelWriterAdapter{io.Discard}, 0)
 	e.EmbedObject(obj)
-	c.l.context = enc.AppendObjectData(c.l.context, e.buf)
+	if len(e.buf) > 1 {
+		c.l.context = enc.AppendObjectData(c.l.context, e.buf)
+	}
 	putEvent(e)
 	return c
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -99,3 +99,46 @@ func Test_InterfaceLogObjectMarshaler(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+type emptyObjectMarshaler struct {
+	name string
+}
+
+func (t *emptyObjectMarshaler) MarshalZerologObject(e *Event) {
+	if t.name != "" {
+		e.Str("name", t.name)
+	}
+}
+
+func TestContext_EmbedObject(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *emptyObjectMarshaler
+		want string
+	}{
+		{
+			name: "empty object",
+			obj:  &emptyObjectMarshaler{name: ""},
+			want: `{"level":"info","parent_field":"parent_value","message":"test"}` + "\n",
+		},
+		{
+			name: "non-empty object",
+			obj:  &emptyObjectMarshaler{name: "Alice"},
+			want: `{"level":"info","parent_field":"parent_value","name":"Alice","message":"test"}` + "\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			parentCtx := New(&buf).With().Str("parent_field", "parent_value")
+			logger := parentCtx.EmbedObject(tt.obj).Logger()
+			logger.Info().Msg("test")
+
+			got := cbor.DecodeIfBinaryToString(buf.Bytes())
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes an issue with Context.EmbedObject() that produces invalid JSON when
- the given object's `MarshalZerologobject` adds no fields (empty object)
- and the parent context has existing fields.


When `MarshalZerologObject` adds no fields (e.g., all fields are conditionally skipped), an extra comma is inserted:

```json
  {"level":"info","parent_field":"parent_value",,"message":"test"}
```
