### PR TITLE
Ensure that Event and Array objects returned to pool are cleared

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,11 @@ is allocated in `sync.Pool` memory that will be returned to the pool as soon as 
 or `MsgFunc()` writes the message and **must not** be accessed afterwards.
 
 **Do not** hold a reference to the `*Event` while in callback functions or your own code. This is especially important in
-`Hook.Run()` and `HookFunc` functions or `MarshalZerologObject(e *Event)` callbacks. Similarly, `Array` objects returned
-from `Context.CreateArray()` or `Event.CreateArray()` are from a `sync.Pool` so don't hold references to them from within
-any `MarshalZerologArray(a *Array)` callback (e.g. `LogArrayMarshaler` implementations).
+`Hook.Run()` and `HookFunc` functions or `MarshalZerologObject(e *Event)` callback (e.g. `LogObjectMarshaler` implementations).
+
+Any `Array` objects returned from `Context.CreateArray()` or `Event.CreateArray()` are from a `sync.Pool` so **do not** hold
+references to them from within any `MarshalZerologArray(a *Array)` callback (e.g. `LogArrayMarshaler` implementations) or your
+own code as they will be cleared and returned to the pool after being buffered by a call to `Context.Array()` or `Event.Array()`.
+
+Any _dictionary_ `Event` returned from `Context.CreateDict()` or `Event.CreateDict()` **must not** be referenced after being
+buffered by a call to `Context.Dict()` or `Event.Dict()` as they will be cleared and returned to the pool.

--- a/array.go
+++ b/array.go
@@ -25,6 +25,12 @@ type Array struct {
 }
 
 func putArray(a *Array) {
+	// prevent any subsequent use of the Array contextual state and truncate the buffer
+	a.stack = false
+	a.ctx = nil
+	a.ch = nil
+	a.buf = a.buf[:0]
+
 	// Proper usage of a sync.Pool requires each entry to have approximately
 	// the same memory cost. To obtain this property when the stored type
 	// contains a variably-sized buffer, we add a hard limit on the maximum buffer
@@ -35,9 +41,6 @@ func putArray(a *Array) {
 	if cap(a.buf) > maxSize {
 		return
 	}
-	a.stack = false
-	a.ctx = nil
-	a.ch = nil
 	arrayPool.Put(a)
 }
 

--- a/event.go
+++ b/event.go
@@ -32,6 +32,15 @@ type Event struct {
 }
 
 func putEvent(e *Event) {
+	// prevent any subsequent use of the Event contextual state and truncate the buffer
+	e.w = nil
+	e.done = nil
+	e.stack = false
+	e.ch = nil
+	e.skipFrame = 0
+	e.ctx = nil
+	e.buf = e.buf[:0]
+
 	// Proper usage of a sync.Pool requires each entry to have approximately
 	// the same memory cost. To obtain this property when the stored type
 	// contains a variably-sized buffer, we add a hard limit on the maximum buffer
@@ -463,8 +472,8 @@ func (e *Event) Ctx(ctx context.Context) *Event {
 }
 
 // GetCtx retrieves the Go context.Context which is optionally stored in the
-// Event.  This allows Hooks and functions passed to Func() to retrieve values
-// which are stored in the context.Context.  This can be useful in tracing,
+// Event. This allows Hooks and functions passed to Func() to retrieve values
+// which are stored in the context.Context. This can be useful in tracing,
 // where span information is commonly propagated in the context.Context.
 func (e *Event) GetCtx() context.Context {
 	if e == nil || e.ctx == nil {


### PR DESCRIPTION
Help ensure no corruptible state remains in objects being returned to the pool.
Always clear the contextual properties to ensure the recycled (or erroneously referenced)
Event or Array are not accidentally used/shared.
Sets the truncates the buffer (setting length, not capacity, to zero).
Make it really obvious when you hold references as mentioned in #733
Clarified the documentation about holding references to CreateDict() events.

Builds on #745 and #746