### PR TITLE
fix: record error field when ErrorStackMarshaler returns nil

### DIFF
--- a/context.go
+++ b/context.go
@@ -210,7 +210,7 @@ func (c Context) Err(err error) Context {
 	if c.l.stack && ErrorStackMarshaler != nil {
 		switch m := ErrorStackMarshaler(err).(type) {
 		case nil:
-			return c // do nothing with nil errors
+			// No stack trace available; continue to record the error field.
 		case LogObjectMarshaler:
 			c = c.Object(ErrorStackFieldName, m)
 		case error:

--- a/context_test.go
+++ b/context_test.go
@@ -70,7 +70,7 @@ func TestContext_ErrWithNilStackMarshaler(t *testing.T) {
 	log.Info().Msg("test message")
 
 	got := decodeIfBinaryToString(buf.Bytes())
-	want := `{"level":"info","message":"test message"}` + "\n" // No stack or error field because stack marshaler returned nil
+	want := `{"level":"info","error":"test error","message":"test message"}` + "\n"
 	if got != want {
 		t.Errorf("Context.Err() with nil stack marshaler = %q, want %q", got, want)
 	}

--- a/event.go
+++ b/event.go
@@ -466,7 +466,7 @@ func (e *Event) Err(err error) *Event {
 	if e.stack && ErrorStackMarshaler != nil {
 		switch m := ErrorStackMarshaler(err).(type) {
 		case nil:
-			return e
+			// No stack trace available; continue to record the error field.
 		case LogObjectMarshaler:
 			e = e.Object(ErrorStackFieldName, m)
 		case error:

--- a/event_test.go
+++ b/event_test.go
@@ -720,7 +720,7 @@ func TestEvent_ErrWithStackMarshalerNil(t *testing.T) {
 	log.Log().Stack().Err(err).Msg("test message")
 
 	got := buf.String()
-	want := `{"message":"test message"}` + "\n" // No fields because stack marshaler returned nil
+	want := `{"error":"test error","message":"test message"}` + "\n"
 	if got != want {
 		t.Errorf("Event.Err() with nil stack marshaler = %q, want %q", got, want)
 	}

--- a/fields.go
+++ b/fields.go
@@ -82,7 +82,7 @@ func appendFieldList(dst []byte, kvList []interface{}, stack bool, ctx context.C
 			if stack && ErrorStackMarshaler != nil {
 				switch m := ErrorStackMarshaler(val).(type) {
 				case nil:
-					return dst // do nothing with nil errors
+					// No stack trace available; continue processing remaining fields.
 				case LogObjectMarshaler:
 					dst = enc.AppendKey(dst, ErrorStackFieldName)
 					dst = appendObject(dst, m, stack, ctx, hooks)


### PR DESCRIPTION
> [!NOTE]  
> I am not certain that this is a bug but it does look like one - at least the behaviour has changed in a way that I am not sure is expected / intended but I'm hoping you folks might be able to help confirm / take a look

In `v1.35`, `Event.Err` / `Context.Err` (and the stack path in `appendFieldList` for error values) return early when `ErrorStackMarshaler(err)` returns `nil`. That skips the subsequent `AnErr` / field encoding, so the main error field is omitted from the log line.

A `nil` return from `ErrorStackMarshaler` means _“nothing to put in the stack field”_ (e.g. plain `errors.New` / `fmt.Errorf` without a pkg/errors-style stack). I don't think it should mean _“omit the error entirely”_

This regressed from `v1.34`, where an empty case `nil` branch still fell through to `AnErr`.

The behavior change was introduced in #748 (commit f6fbd33).


## How to Reproduce

Minimal setup: enable stack on the logger (`With().Stack()` or `log.Log().Stack())`, set a global `ErrorStackMarshaler` that returns `nil` (same idea as `go.elastic.co/ecszerolog/internal.MarshallStack` for plain `errors.New` / `fmt.Errorf errors`), then log with `.Err(err).Msg("...")`.

With zerolog `v1.34.x`, the JSON line includes the error field (default key "`error`", or whatever `ErrorFieldName` is set to, e.g. ECS `error.message`).

With zerolog `v1.35.x`, that field is missing: the line typically only has message (and level/timestamp), even though `err` is non-nil.

## Extra Notes / Question

When `ErrorStackMarshaler(err)` returns `nil`, is it intentional that `Err()` no longer records the main error field (i.e. `AnErr` is skipped), or should nil mean only _“no value for the stack field”,_ with the error text still emitted as in `v1.34`?

If the new behaviour is intended, it would help to document that `nil` from `ErrorStackMarshaler` suppresses the entire `Err()` payload, since that affects common setups (e.g. ECS logging) where `nil` only indicates _“no stack trace available”_ for typical Go errors I think.

#748’s description says Context/Fields were restructured when ErrorStackMarshaler returns nil for coverage but it doesn’t define intended behaviour for whether `Err()` should still record the error. Was dropping the error field intentional? Or am I maybe doing something wrong?