### PR TITLE
fix: Err() should record error when ErrorStackMarshaler returns nil

### DIFF
--- a/context.go
+++ b/context.go
@@ -210,7 +210,8 @@ func (c Context) Err(err error) Context {
 	if c.l.stack && ErrorStackMarshaler != nil {
 		switch m := ErrorStackMarshaler(err).(type) {
 		case nil:
-			return c // do nothing with nil errors
+			// Stack marshaler returned nil; skip the stack field
+			// but still record the error below.
 		case LogObjectMarshaler:
 			c = c.Object(ErrorStackFieldName, m)
 		case error:

--- a/event.go
+++ b/event.go
@@ -466,7 +466,8 @@ func (e *Event) Err(err error) *Event {
 	if e.stack && ErrorStackMarshaler != nil {
 		switch m := ErrorStackMarshaler(err).(type) {
 		case nil:
-			return e
+			// Stack marshaler returned nil; skip the stack field
+			// but still record the error below.
 		case LogObjectMarshaler:
 			e = e.Object(ErrorStackFieldName, m)
 		case error:


### PR DESCRIPTION
Fixes #762

## Problem

Since commit f6fbd33, when `ErrorStackMarshaler` returns `nil` (e.g. for errors that don't have stack traces), `Err()` returns immediately without calling `AnErr(ErrorFieldName, err)`. This silently drops the error message from log output.

Before the regression:
```json
{"level":"error","error":"something failed","message":"..."}
```

After the regression:
```json
{"level":"error","message":"..."}
```
(error field is missing!)

## Fix

Change `case nil: return e` to an empty `case nil:` so control falls through to the `AnErr()` call that records the error field. The stack field is correctly skipped when the marshaler returns nil.