### PR TITLE
Fixed the same missing Err() issue in context.go

### DIFF
--- a/context.go
+++ b/context.go
@@ -210,7 +210,8 @@ func (c Context) Err(err error) Context {
 	if c.l.stack && ErrorStackMarshaler != nil {
 		switch m := ErrorStackMarshaler(err).(type) {
 		case nil:
-			return c // do nothing with nil errors
+			// ErrorStackMarshaler returned nil — the error has no stack trace to
+			// attach. Fall through and still log the error via AnErr below.
 		case LogObjectMarshaler:
 			c = c.Object(ErrorStackFieldName, m)
 		case error:

--- a/context_test.go
+++ b/context_test.go
@@ -70,7 +70,10 @@ func TestContext_ErrWithNilStackMarshaler(t *testing.T) {
 	log.Info().Msg("test message")
 
 	got := decodeIfBinaryToString(buf.Bytes())
-	want := `{"level":"info","message":"test message"}` + "\n" // No stack or error field because stack marshaler returned nil
+	// When ErrorStackMarshaler returns nil (no stack trace available for this
+	// error), Err() must still log the error value via AnErr. Without a stack
+	// field, the output is the same as if Stack() had not been called.
+	want := `{"level":"info","error":"test error","message":"test message"}` + "\n"
 	if got != want {
 		t.Errorf("Context.Err() with nil stack marshaler = %q, want %q", got, want)
 	}


### PR DESCRIPTION
Since #763 was merged instead of #758, only event.go was fixed. Need the same fix for context.go
