### PR TITLE
fix: respect PartsExclude in writeFields

### DIFF
--- a/console.go
+++ b/console.go
@@ -201,6 +201,18 @@ func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer
 		case LevelFieldName, TimestampFieldName, MessageFieldName, CallerFieldName:
 			continue
 		}
+
+		var isPartsExcluded bool
+		for _, excluded := range w.PartsExclude {
+			if field == excluded {
+				isPartsExcluded = true
+				break
+			}
+		}
+		if isPartsExcluded {
+			continue
+		}
+
 		fields = append(fields, field)
 	}
 

--- a/console_test.go
+++ b/console_test.go
@@ -567,6 +567,28 @@ func TestConsoleWriterConfiguration(t *testing.T) {
 		}
 	})
 
+	t.Run("PartsExclude suppresses fields from writeFields", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		w := zerolog.ConsoleWriter{
+			Out:          buf,
+			NoColor:      true,
+			PartsExclude: []string{"pkg"},
+		}
+
+		evt := `{"level": "info", "message": "Hello", "pkg": "main"}`
+		_, err := w.Write([]byte(evt))
+		if err != nil {
+			t.Errorf("Unexpected error when writing output: %s", err)
+		}
+
+		// "pkg" in PartsExclude should be excluded from both writePart and writeFields
+		expectedOutput := "<nil> INF Hello\n"
+		actualOutput := buf.String()
+		if actualOutput != expectedOutput {
+			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
+		}
+	})
+
 	t.Run("Sets FormatExtra", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		w := zerolog.ConsoleWriter{


### PR DESCRIPTION
## Summary

Fields listed in `PartsExclude` were only excluded from `writePart` (which handles standard fields like `level`, `time`, `message`, and custom fields rendered via `PartsOrder`), but were still rendered by `writeFields`, causing them to appear in the trailing `key=value` section of the output.

This PR fixes `writeFields` to also skip fields listed in `PartsExclude`.

## Related Issue

Fixes rs/zerolog#722

## Changes

- `console.go`: In `writeFields`, skip any field that is listed in `PartsExclude`
- `console_test.go`: Add test verifying that `PartsExclude` suppresses fields from both `writePart` and `writeFields`