### PR TITLE
Skip missing custom ConsoleWriter parts instead of printing %!s(<nil>)

### DIFF
--- a/console.go
+++ b/console.go
@@ -330,6 +330,13 @@ func (w ConsoleWriter) writePart(buf *bytes.Buffer, evt map[string]interface{}, 
 		} else if w.FormatFieldValue != nil {
 			f = w.FormatFieldValue
 		} else {
+			// A custom part listed in PartsOrder may be absent from the event
+			// (for example when using the global logger). Without a custom
+			// formatter the default one renders the missing value as
+			// "%!s(<nil>)", so skip the part entirely instead. See #710.
+			if evt[p] == nil {
+				return
+			}
 			f = consoleDefaultFormatFieldValue
 		}
 	}

--- a/console_test.go
+++ b/console_test.go
@@ -118,6 +118,22 @@ func TestConsoleWriter(t *testing.T) {
 		}
 	})
 
+	t.Run("Missing custom part is skipped", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		w := zerolog.ConsoleWriter{Out: buf, NoColor: true, PartsOrder: []string{"level", "request_id", "message"}}
+
+		_, err := w.Write([]byte(`{"level": "info", "message": "Starting server"}`))
+		if err != nil {
+			t.Errorf("Unexpected error when writing output: %s", err)
+		}
+
+		expectedOutput := "INF Starting server\n"
+		actualOutput := buf.String()
+		if actualOutput != expectedOutput {
+			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
+		}
+	})
+
 	t.Run("Write colorized", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		w := zerolog.ConsoleWriter{Out: buf, NoColor: false}


### PR DESCRIPTION
Fixes #710. When a custom name in PartsOrder (like request_id) isn't present in the event, for instance on the global logger where the field was only set on a request-scoped logger, writePart falls through to consoleDefaultFormatFieldValue and formats the nil value as the literal "%!s(<nil>)", which then gets written to the line. This returns early for a missing custom part when no custom field-value formatter is configured, so the part is skipped rather than printing garbage.

I added a ConsoleWriter test that logs with a request_id in PartsOrder but absent from the event and asserts the "%!s(<nil>)" no longer leaks. It fails before the change and passes after, and the full go test ./... suite, go vet, and go fmt are all clean. Thanks for taking a look.