### PR TITLE
docs: fix WithContext and BurstSampler godoc wording

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -15,7 +15,7 @@ func init() {
 type ctxKey struct{}
 
 // WithContext returns a copy of ctx with the receiver attached. The Logger
-// attached to the provided Context (if any) will not be effected.  If the
+// attached to the provided Context (if any) will not be affected. If the
 // receiver's log level is Disabled it will only be attached to the returned
 // Context if the provided Context has a previously attached Logger. If the
 // provided Context has no attached Logger, a Disabled Logger will not be

--- a/sampler.go
+++ b/sampler.go
@@ -37,7 +37,7 @@ func (s RandomSampler) Sample(lvl Level) bool {
 	return true
 }
 
-// BasicSampler is a sampler that will send every Nth events, regardless of
+// BasicSampler is a sampler that will send every Nth event, regardless of
 // their level.
 type BasicSampler struct {
 	N       uint32
@@ -58,7 +58,7 @@ func (s *BasicSampler) Sample(lvl Level) bool {
 }
 
 // BurstSampler lets Burst events pass per Period then pass the decision to
-// NextSampler. If Sampler is not set, all subsequent events are rejected.
+// NextSampler. If NextSampler is not set, all subsequent events are rejected.
 type BurstSampler struct {
 	// Burst is the maximum number of event per period allowed before calling
 	// NextSampler.


### PR DESCRIPTION
## Summary
Small godoc cleanups:
- `WithContext`: \"effected\" → \"affected\"
- `BurstSampler`: type comment said \"If Sampler is not set\" but the field is `NextSampler`
- `BasicSampler`: \"every Nth events\" → \"every Nth event\"

## Test plan
- docs only