### PR TITLE
fix(syslog): make Trace→Debug level mapping explicit

### DIFF
--- a/syslog.go
+++ b/syslog.go
@@ -56,8 +56,8 @@ func (sw syslogWriter) Write(p []byte) (n int, err error) {
 // WriteLevel implements LevelWriter interface.
 func (sw syslogWriter) WriteLevel(level Level, p []byte) (n int, err error) {
 	switch level {
-	case TraceLevel:
-	case DebugLevel:
+	case TraceLevel, DebugLevel:
+		// syslog has no TRACE severity; map Trace to Debug
 		err = sw.w.Debug(sw.prefix + string(p))
 	case InfoLevel:
 		err = sw.w.Info(sw.prefix + string(p))

--- a/syslog_test.go
+++ b/syslog_test.go
@@ -61,6 +61,7 @@ func TestSyslogWriter(t *testing.T) {
 	log.Error().Msg("error")
 	log.Log().Msg("nolevel")
 	want := []syslogEvent{
+		{"Debug", `{"level":"trace","message":"trace"}` + "\n"}, // syslog has no TRACE; mapped to Debug
 		{"Debug", `{"level":"debug","message":"debug"}` + "\n"},
 		{"Info", `{"level":"info","message":"info"}` + "\n"},
 		{"Warning", `{"level":"warn","message":"warn"}` + "\n"},
@@ -173,6 +174,7 @@ func TestSyslogWriter_WriteLevel_AllLevels(t *testing.T) {
 	writer.WriteLevel(NoLevel, []byte(`{"message":"nolevel"}`+"\n"))
 
 	want := []syslogEvent{
+		{"Debug", `{"level":"trace","message":"trace"}` + "\n"}, // syslog has no TRACE; mapped to Debug
 		{"Debug", `{"level":"debug","message":"debug"}` + "\n"},
 		{"Info", `{"level":"info","message":"info"}` + "\n"},
 		{"Warning", `{"level":"warn","message":"warn"}` + "\n"},


### PR DESCRIPTION
## Summary
`WriteLevel` had an empty `case TraceLevel:` above `case DebugLevel:`. In Go that does **not** fall through, so Trace events were silently dropped (tests previously encoded that).

This change groups `TraceLevel` with `DebugLevel` so Trace maps to syslog `Debug`, with a short comment that syslog has no TRACE severity.

## Test plan
- Updated `TestSyslogWriter` and `TestSyslogWriter_WriteLevel_AllLevels` to expect Trace→Debug
- `go test -run 'TestSyslogWriter$|TestSyslogWriter_WriteLevel_AllLevels' .`