### PR TITLE
tests: isolate console color expectations

### DIFF
--- a/console_test.go
+++ b/console_test.go
@@ -102,6 +102,8 @@ func TestConsoleLogger(t *testing.T) {
 }
 
 func TestConsoleWriter(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+
 	t.Run("Default field formatter", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		w := zerolog.ConsoleWriter{Out: buf, NoColor: true, PartsOrder: []string{"foo"}}


### PR DESCRIPTION
Clear `NO_COLOR` for `TestConsoleLogger` so its ANSI-color expectations do not depend on the caller or CI environment. `t.Setenv` restores the original value after the test.

Testing:
- `go test .`
- `go vet .`