### PR TITLE
journald: isolate byte count test from the host journal

### DIFF
--- a/journald/journald_test.go
+++ b/journald/journald_test.go
@@ -81,6 +81,11 @@ func TestSanitizeKey(t *testing.T) {
 }
 
 func TestWriteReturnsNoOfWrittenBytes(t *testing.T) {
+	mock := &mockSend{}
+	oldSend := SendFunc
+	SendFunc = mock.send
+	defer func() { SendFunc = oldSend }()
+
 	input := []byte(`{"level":"info","time":1570912626,"message":"Starting..."}`)
 	wr := NewJournalDWriter()
 	want := len(input)


### PR DESCRIPTION
Install the existing `mockSend` for `TestWriteBytesWritten` and restore `SendFunc` afterward. The test is intended to verify the returned byte count, so it should not depend on whether the host exposes a working systemd journal socket.

Testing:
- `go test ./journald`
- `go vet ./journald`