### PR TITLE
fix(console): return error when ConsoleWriter.Out is nil

### DIFF
--- a/console.go
+++ b/console.go
@@ -120,6 +120,9 @@ func NewConsoleWriter(options ...func(w *ConsoleWriter)) ConsoleWriter {
 
 // Write transforms the JSON input with formatters and appends to w.Out.
 func (w ConsoleWriter) Write(p []byte) (n int, err error) {
+	if w.Out == nil {
+		return 0, fmt.Errorf("zerolog: ConsoleWriter.Out is nil")
+	}
 	// Fix color on Windows
 	if w.Out == os.Stdout || w.Out == os.Stderr {
 		w.Out = colorable.NewColorable(w.Out.(*os.File))

--- a/console_test.go
+++ b/console_test.go
@@ -654,3 +654,14 @@ func BenchmarkConsoleWriter(b *testing.B) {
 		w.Write(msg)
 	}
 }
+
+func TestConsoleWriterNilOut(t *testing.T) {
+	w := zerolog.ConsoleWriter{Out: nil, NoColor: true}
+	_, err := w.Write([]byte(`{"level":"info","message":"hi"}`))
+	if err == nil {
+		t.Fatal("expected error for nil Out")
+	}
+	if !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
A zero-value `ConsoleWriter` leaves `Out` nil. `Write` then panics when it tries to write the formatted line.

Return a clear error instead of panicking so misconfiguration fails safely.

## Test plan
- [x] `go test -run Console`
- [x] New unit test covering nil `Out`