### PR TITLE
fix: ParseLevel accepts "warning" as warn

### DIFF
--- a/log.go
+++ b/log.go
@@ -183,7 +183,8 @@ func ParseLevel(levelStr string) (Level, error) {
 		return DebugLevel, nil
 	case strings.EqualFold(levelStr, LevelFieldMarshalFunc(InfoLevel)):
 		return InfoLevel, nil
-	case strings.EqualFold(levelStr, LevelFieldMarshalFunc(WarnLevel)):
+	case strings.EqualFold(levelStr, LevelFieldMarshalFunc(WarnLevel)),
+		strings.EqualFold(levelStr, "warning"):
 		return WarnLevel, nil
 	case strings.EqualFold(levelStr, LevelFieldMarshalFunc(ErrorLevel)):
 		return ErrorLevel, nil

--- a/log_test.go
+++ b/log_test.go
@@ -1455,3 +1455,14 @@ func TestHTMLNoEscaping(t *testing.T) {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
 }
+
+func TestParseLevelWarningAlias(t *testing.T) {
+	l, err := ParseLevel("warning")
+	if err != nil || l != WarnLevel {
+		t.Fatalf("ParseLevel(warning)=%v %v", l, err)
+	}
+	l, err = ParseLevel("WARNING")
+	if err != nil || l != WarnLevel {
+		t.Fatalf("ParseLevel(WARNING)=%v %v", l, err)
+	}
+}


### PR DESCRIPTION
## Summary

`ParseLevel("warning")` failed even though many configs and libraries use that name for warn. Accept `warning` (any case) as `WarnLevel`.

## Test plan

- [x] `go test -run TestParseLevel`