### PR TITLE
fix(console): do not re-print PartsOrder fields in writeFields

### DIFF
--- a/console.go
+++ b/console.go
@@ -196,6 +196,25 @@ func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer
 		if isExcluded {
 			continue
 		}
+		// Parts already rendered via PartsOrder (including custom part names)
+		// must not be duplicated here. PartsExclude also suppresses remaining output.
+		for _, part := range w.PartsOrder {
+			if field == part {
+				isExcluded = true
+				break
+			}
+		}
+		if !isExcluded {
+			for _, excluded := range w.PartsExclude {
+				if field == excluded {
+					isExcluded = true
+					break
+				}
+			}
+		}
+		if isExcluded {
+			continue
+		}
 
 		switch field {
 		case LevelFieldName, TimestampFieldName, MessageFieldName, CallerFieldName:

--- a/console_test.go
+++ b/console_test.go
@@ -113,7 +113,7 @@ func TestConsoleWriter(t *testing.T) {
 			t.Errorf("Unexpected error when writing output: %s", err)
 		}
 
-		expectedOutput := "DEFAULT foo=DEFAULT\n"
+		expectedOutput := "DEFAULT\n"
 		actualOutput := buf.String()
 		if actualOutput != expectedOutput {
 			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
@@ -563,6 +563,54 @@ func TestConsoleWriterConfiguration(t *testing.T) {
 		}
 
 		expectedOutput := "<nil> INF Foobar baz=quux\n"
+		actualOutput := buf.String()
+		if actualOutput != expectedOutput {
+			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
+		}
+	})
+
+	t.Run("PartsOrder custom fields are not duplicated", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		w := zerolog.ConsoleWriter{
+			Out:     buf,
+			NoColor: true,
+			PartsOrder: []string{
+				zerolog.LevelFieldName,
+				"pkg",
+				"fn",
+				zerolog.MessageFieldName,
+			},
+		}
+
+		evt := `{"level": "info", "message": "This is a test.", "pkg": "main", "fn": "TestFunc"}`
+		_, err := w.Write([]byte(evt))
+		if err != nil {
+			t.Errorf("Unexpected error when writing output: %s", err)
+		}
+
+		expectedOutput := "INF main TestFunc This is a test.\n"
+		actualOutput := buf.String()
+		if actualOutput != expectedOutput {
+			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
+		}
+	})
+
+	t.Run("PartsExclude suppresses custom fields from trailing writeFields", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		w := zerolog.ConsoleWriter{
+			Out:          buf,
+			NoColor:      true,
+			PartsOrder:   []string{zerolog.LevelFieldName, zerolog.MessageFieldName},
+			PartsExclude: []string{"pkg"},
+		}
+
+		evt := `{"level": "info", "message": "This is a test.", "pkg": "main", "fn": "TestFunc"}`
+		_, err := w.Write([]byte(evt))
+		if err != nil {
+			t.Errorf("Unexpected error when writing output: %s", err)
+		}
+
+		expectedOutput := "INF This is a test. fn=TestFunc\n"
 		actualOutput := buf.String()
 		if actualOutput != expectedOutput {
 			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)


### PR DESCRIPTION
Fixes #722

## Summary

`ConsoleWriter` printed custom fields listed in `PartsOrder` twice: once via `writePart` and again via trailing `writeFields`.

## Changes

- Skip field names already present in `PartsOrder` when building the trailing field list
- Also honor `PartsExclude` for trailing fields (same exclusion semantics as ordered parts)
- Tests for no-duplication and PartsExclude on custom fields
- Adjust `Default field formatter` expectation (custom part value is no longer also emitted as `key=value`)

## Test plan

- [x] `go test ./...`