### PR TITLE
Rewrite SlogHandler for spec-compliant timestamps, callers, and groups

### DIFF
--- a/slog.go
+++ b/slog.go
@@ -94,7 +94,7 @@ func (h *SlogHandler) Handle(ctx context.Context, record slog.Record) error {
 
 	// Add timestamp using slog.Record.Time
 	if h.hasTimestampHook && !record.Time.IsZero() {
-		e.buf = enc.AppendTime(enc.AppendKey(e.buf, TimestampFieldName), record.Time, TimeFieldFormat)
+		e = e.Time(TimestampFieldName, record.Time)
 	}
 
 	// Add caller using slog.Record.PC

--- a/slog.go
+++ b/slog.go
@@ -134,8 +134,7 @@ func (h *SlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 
 func (h *SlogHandler) appendUnopenedGroups(buf []byte) []byte {
 	for _, group := range h.unopenedGroups {
-		buf = enc.AppendKey(buf, group)
-		buf = enc.AppendBeginMarker(buf)
+		buf = enc.AppendBeginMarker(enc.AppendKey(buf, group))
 	}
 	return buf
 }
@@ -179,6 +178,7 @@ func appendSlogAttrToEvent(event *Event, attr slog.Attr) *Event {
 	}
 
 	attr.Value = attr.Value.Resolve()
+
 	if attr.Equal(slog.Attr{}) {
 		return event
 	}
@@ -283,7 +283,6 @@ func appendSlogAttrToContext(ctx Context, attr slog.Attr) Context {
 
 	key := attr.Key
 	val := attr.Value
-
 	switch val.Kind() {
 	case slog.KindString:
 		ctx = ctx.Str(key, val.String())

--- a/slog.go
+++ b/slog.go
@@ -66,46 +66,59 @@ func (h *SlogHandler) Enabled(_ context.Context, level slog.Level) bool {
 
 // Handle converts the slog.Record to a zerolog event and writes it.
 func (h *SlogHandler) Handle(ctx context.Context, record slog.Record) error {
-	e := h.logger.WithLevel(slogToZerologLevel(record.Level))
-	if e == nil {
+	event := h.logger.WithLevel(slogToZerologLevel(record.Level))
+	if event == nil {
 		return nil
 	}
 
 	if ctx != nil {
-		e = e.Ctx(ctx)
+		event = event.Ctx(ctx)
 	}
 
 	nOpenGroups := h.nOpenGroups
 
 	if record.NumAttrs() > 0 {
-		e.buf = h.appendUnopenedGroups(e.buf)
-		nOpenGroups += len(h.unopenedGroups)
+		// The group may turn out to be empty even though it has attrs (for example, all attrs are zero slog.Attr).
+		// So remember where we are in the buffer, to restore the position later if necessary.
+		pos := len(event.buf)
+		event.buf = h.appendUnopenedGroups(event.buf)
 
+		notEmpty := false
 		record.Attrs(func(a slog.Attr) bool {
-			e = appendSlogAttrToEvent(e, a)
+			e, changed := appendSlogAttrToEvent(event, a)
+			event = e
+			if changed {
+				notEmpty = true
+			}
 			return true
 		})
+
+		if notEmpty {
+			nOpenGroups += len(h.unopenedGroups)
+		} else {
+			event.buf = event.buf[:pos]
+		}
 	}
 
 	// Close all opened groups
 	for range nOpenGroups {
-		e.buf = enc.AppendEndMarker(e.buf)
+		event.buf = enc.AppendEndMarker(event.buf)
 	}
 
 	// Add timestamp using slog.Record.Time
 	if h.hasTimestampHook && !record.Time.IsZero() {
-		e = e.Time(TimestampFieldName, record.Time)
+		event = event.Time(TimestampFieldName, record.Time)
 	}
 
 	// Add caller using slog.Record.PC
 	if h.hasCallerHook && record.PC != 0 {
 		f, _ := runtime.CallersFrames([]uintptr{record.PC}).Next()
 		if f.PC != 0 {
-			e.buf = enc.AppendString(enc.AppendKey(e.buf, CallerFieldName), CallerMarshalFunc(f.PC, f.File, f.Line))
+			event.buf = enc.AppendString(enc.AppendKey(event.buf, CallerFieldName), CallerMarshalFunc(f.PC, f.File, f.Line))
 		}
 	}
 
-	e.Msg(record.Message)
+	event.Msg(record.Message)
 	return nil
 }
 
@@ -117,15 +130,27 @@ func (h *SlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	}
 
 	h2 := *h
+	ctx := h2.logger.With()
 
-	ctx := h.logger.With()
+	// The group may turn out to be empty even though it has attrs (for example, all attrs are zero slog.Attr).
+	// So remember where we are in the buffer, to restore the position later if necessary.
+	pos := len(ctx.l.context)
+	ctx.l.context = h2.appendUnopenedGroups(ctx.l.context)
 
-	ctx.l.context = h.appendUnopenedGroups(ctx.l.context)
-	h2.nOpenGroups += len(h2.unopenedGroups)
-	h2.unopenedGroups = nil
-
+	notEmpty := false
 	for _, attr := range attrs {
-		ctx = appendSlogAttrToContext(ctx, attr)
+		c, changed := appendSlogAttrToContext(ctx, attr)
+		ctx = c
+		if changed {
+			notEmpty = true
+		}
+	}
+
+	if notEmpty {
+		h2.nOpenGroups += len(h2.unopenedGroups)
+		h2.unopenedGroups = nil
+	} else {
+		ctx.l.context = ctx.l.context[:pos]
 	}
 
 	h2.logger = ctx.Logger()
@@ -172,15 +197,15 @@ func slogToZerologLevel(level slog.Level) Level {
 }
 
 // appendSlogAttrToEvent appends a single slog.Attr to the zerolog event, handling type-specific encoding to avoid reflection where possible.
-func appendSlogAttrToEvent(event *Event, attr slog.Attr) *Event {
+func appendSlogAttrToEvent(event *Event, attr slog.Attr) (*Event, bool) {
 	if event == nil {
-		return event
+		return event, false
 	}
 
 	attr.Value = attr.Value.Resolve()
 
 	if attr.Equal(slog.Attr{}) {
-		return event
+		return event, false
 	}
 
 	key := attr.Key
@@ -202,19 +227,36 @@ func appendSlogAttrToEvent(event *Event, attr slog.Attr) *Event {
 		event = event.Time(key, val.Time())
 	case slog.KindGroup:
 		attrs := val.Group()
-		if len(attrs) > 0 {
-			if key == "" {
-				for _, ga := range attrs {
-					event = appendSlogAttrToEvent(event, ga)
+		if len(attrs) == 0 {
+			return event, false
+		}
+
+		if key == "" {
+			notEmpty := false
+			for _, ga := range attrs {
+				e, changed := appendSlogAttrToEvent(event, ga)
+				event = e
+				if changed {
+					notEmpty = true
 				}
-			} else {
-				dict := event.CreateDict()
-				for _, ga := range attrs {
-					dict = appendSlogAttrToEvent(dict, ga)
-				}
-				event = event.Dict(key, dict)
+			}
+			return event, notEmpty
+		}
+
+		dict := event.CreateDict()
+		notEmpty := false
+		for _, ga := range attrs {
+			d, changed := appendSlogAttrToEvent(dict, ga)
+			dict = d
+			if changed {
+				notEmpty = true
 			}
 		}
+		if !notEmpty {
+			putEvent(dict)
+			return event, false
+		}
+		event = event.Dict(key, dict)
 	case slog.KindAny:
 		v := val.Any()
 		switch cv := v.(type) {
@@ -271,14 +313,14 @@ func appendSlogAttrToEvent(event *Event, attr slog.Attr) *Event {
 		event = event.Interface(key, val.Any())
 	}
 
-	return event
+	return event, true
 }
 
-func appendSlogAttrToContext(ctx Context, attr slog.Attr) Context {
+func appendSlogAttrToContext(ctx Context, attr slog.Attr) (Context, bool) {
 	attr.Value = attr.Value.Resolve()
 
 	if attr.Equal(slog.Attr{}) {
-		return ctx
+		return ctx, false
 	}
 
 	key := attr.Key
@@ -300,19 +342,36 @@ func appendSlogAttrToContext(ctx Context, attr slog.Attr) Context {
 		ctx = ctx.Time(key, val.Time())
 	case slog.KindGroup:
 		attrs := val.Group()
-		if len(attrs) > 0 {
-			if key == "" {
-				for _, ga := range attrs {
-					ctx = appendSlogAttrToContext(ctx, ga)
+		if len(attrs) == 0 {
+			return ctx, false
+		}
+
+		if key == "" {
+			notEmpty := false
+			for _, ga := range attrs {
+				c, changed := appendSlogAttrToContext(ctx, ga)
+				ctx = c
+				if changed {
+					notEmpty = true
 				}
-			} else {
-				dict := ctx.CreateDict()
-				for _, ga := range attrs {
-					dict = appendSlogAttrToEvent(dict, ga)
-				}
-				ctx = ctx.Dict(key, dict)
+			}
+			return ctx, notEmpty
+		}
+
+		dict := ctx.CreateDict()
+		notEmpty := false
+		for _, ga := range attrs {
+			d, changed := appendSlogAttrToEvent(dict, ga)
+			dict = d
+			if changed {
+				notEmpty = true
 			}
 		}
+		if !notEmpty {
+			putEvent(dict)
+			return ctx, false
+		}
+		ctx = ctx.Dict(key, dict)
 	case slog.KindAny:
 		v := val.Any()
 		switch cv := v.(type) {
@@ -369,7 +428,7 @@ func appendSlogAttrToContext(ctx Context, attr slog.Attr) Context {
 		ctx = ctx.Interface(key, val.Any())
 	}
 
-	return ctx
+	return ctx, true
 }
 
 // Verify at compile time that SlogHandler satisfies the slog.Handler interface.

--- a/slog.go
+++ b/slog.go
@@ -3,84 +3,110 @@ package zerolog
 import (
 	"context"
 	"log/slog"
+	"net"
+	"runtime"
 	"time"
 )
 
-// SlogHandler implements the slog.Handler interface using a zerolog.Logger
-// as the underlying log backend. This allows code that uses the standard
-// library's slog package to route log output through zerolog.
+// SlogHandler implements slog.Handler using a zerolog.Logger as the backend.
 type SlogHandler struct {
 	logger Logger
-	prefix string // group prefix for nested groups
-	attrs  []slog.Attr
+
+	unopenedGroups []string // groups from WithGroup that haven't been opened in the output buffer
+	nOpenGroups    int      // number of groups currently open in the output buffer
+
+	hasTimestampHook bool
+	hasCallerHook    bool
 }
 
-// NewSlogHandler creates a new slog.Handler that writes log records to the
-// given zerolog.Logger. The handler maps slog levels to zerolog levels and
-// converts slog attributes to zerolog fields.
+// NewSlogHandler creates a slog.Handler using the given zerolog.Logger as the backend.
+//
+// If the logger was configured with Timestamp() or Caller(), those hooks are stripped and their values sourced from slog.Record instead.
+// This is required for two reasons:
+//
+//   - A zero slog.Record.Time must produce no time field (slog.Handler contract).
+//
+//   - slog.Record.PC resolves the correct call site.
 func NewSlogHandler(logger Logger) *SlogHandler {
-	return &SlogHandler{logger: logger}
+	h := &SlogHandler{}
+
+	hooks := make([]Hook, 0, len(logger.hooks))
+	for _, hook := range logger.hooks {
+		if _, ok := hook.(timestampHook); ok {
+			h.hasTimestampHook = true
+			continue
+		}
+		if _, ok := hook.(callerHook); ok {
+			h.hasCallerHook = true
+			continue
+		}
+		hooks = append(hooks, hook)
+	}
+	logger.hooks = hooks
+
+	h.logger = logger
+	return h
 }
 
 // Enabled reports whether the handler handles records at the given level.
-// It mirrors Logger.should's level and writer checks (without sampling).
 func (h *SlogHandler) Enabled(_ context.Context, level slog.Level) bool {
-	if h.logger.w == nil {
-		return false
-	}
+	// It is equivalent to Logger.should, except that it does not invoke the configured Sampler.
+	// slog.Logger calls Handler.Enabled before creating a slog.Record, while zerolog calls Logger.should (which performs sampling) when creating an Event.
+	// Calling Logger.should here would cause the sampler to run twice for the same log entry, potentially dropping logs incorrectly.
 	zl := slogToZerologLevel(level)
-	if zl < GlobalLevel() {
+
+	if h.logger.disabled() {
 		return false
 	}
-	return zl >= h.logger.level
+	if zl < h.logger.level || zl < GlobalLevel() {
+		return false
+	}
+	return true
 }
 
-// Handle handles the Record. It converts the slog.Record into a zerolog event
-// and writes it using the underlying zerolog.Logger.
+// Handle converts the slog.Record to a zerolog event and writes it.
 func (h *SlogHandler) Handle(ctx context.Context, record slog.Record) error {
-	zlevel := slogToZerologLevel(record.Level)
-	event := h.logger.WithLevel(zlevel)
-	if event == nil {
+	e := h.logger.WithLevel(slogToZerologLevel(record.Level))
+	if e == nil {
 		return nil
 	}
 
-	// Propagate slog context to the zerolog event so that hooks
-	// relying on Event.GetCtx() (e.g. tracing) can access it.
 	if ctx != nil {
-		event = event.Ctx(ctx)
+		e = e.Ctx(ctx)
 	}
 
-	// Add pre-attached attrs from WithAttrs
-	for _, a := range h.attrs {
-		event = appendSlogAttr(event, a, h.prefix)
-	}
+	nOpenGroups := h.nOpenGroups
 
-	// Add attrs from the record itself
-	record.Attrs(func(a slog.Attr) bool {
-		event = appendSlogAttr(event, a, h.prefix)
-		return true
-	})
+	if record.NumAttrs() > 0 {
+		e.buf = h.appendUnopenedGroups(e.buf)
+		nOpenGroups += len(h.unopenedGroups)
 
-	// Add timestamp from the slog record, but only if the logger doesn't
-	// already have a timestampHook (added via .With().Timestamp()) to
-	// avoid duplicate timestamp keys in the output.
-	if !record.Time.IsZero() && !h.hasTimestampHook() {
-		event.Time(TimestampFieldName, record.Time)
-	}
-
-	event.Msg(record.Message)
-	return nil
-}
-
-// hasTimestampHook reports whether the logger has a timestampHook installed,
-// which would cause duplicate timestamp fields if we also emit record.Time.
-func (h *SlogHandler) hasTimestampHook() bool {
-	for _, hook := range h.logger.hooks {
-		if _, ok := hook.(timestampHook); ok {
+		record.Attrs(func(a slog.Attr) bool {
+			e = appendSlogAttrToEvent(e, a)
 			return true
+		})
+	}
+
+	// Close all opened groups
+	for range nOpenGroups {
+		e.buf = enc.AppendEndMarker(e.buf)
+	}
+
+	// Add timestamp using slog.Record.Time
+	if h.hasTimestampHook && !record.Time.IsZero() {
+		e.buf = enc.AppendTime(enc.AppendKey(e.buf, TimestampFieldName), record.Time, TimeFieldFormat)
+	}
+
+	// Add caller using slog.Record.PC
+	if h.hasCallerHook && record.PC != 0 {
+		f, _ := runtime.CallersFrames([]uintptr{record.PC}).Next()
+		if f.PC != 0 {
+			e.buf = enc.AppendString(enc.AppendKey(e.buf, CallerFieldName), CallerMarshalFunc(f.PC, f.File, f.Line))
 		}
 	}
-	return false
+
+	e.Msg(record.Message)
+	return nil
 }
 
 // WithAttrs returns a new Handler with the given attributes pre-attached.
@@ -89,36 +115,42 @@ func (h *SlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	if len(attrs) == 0 {
 		return h
 	}
-	h2 := h.clone()
-	h2.attrs = append(h2.attrs, attrs...)
-	return h2
+
+	h2 := *h
+
+	ctx := h.logger.With()
+
+	ctx.l.context = h.appendUnopenedGroups(ctx.l.context)
+	h2.nOpenGroups += len(h2.unopenedGroups)
+	h2.unopenedGroups = nil
+
+	for _, attr := range attrs {
+		ctx = appendSlogAttrToContext(ctx, attr)
+	}
+
+	h2.logger = ctx.Logger()
+	return &h2
 }
 
-// WithGroup returns a new Handler with the given group name. All subsequent
-// attributes will be nested under this group name in the output.
+func (h *SlogHandler) appendUnopenedGroups(buf []byte) []byte {
+	for _, group := range h.unopenedGroups {
+		buf = enc.AppendKey(buf, group)
+		buf = enc.AppendBeginMarker(buf)
+	}
+	return buf
+}
+
+// WithGroup returns a new Handler with the given group name. All subsequent attributes are nested under name in the output.
 func (h *SlogHandler) WithGroup(name string) slog.Handler {
 	if name == "" {
 		return h
 	}
-	h2 := h.clone()
-	if h2.prefix != "" {
-		h2.prefix = h2.prefix + "." + name
-	} else {
-		h2.prefix = name
-	}
-	return h2
-}
 
-func (h *SlogHandler) clone() *SlogHandler {
-	h2 := &SlogHandler{
-		logger: h.logger,
-		prefix: h.prefix,
-	}
-	if len(h.attrs) > 0 {
-		h2.attrs = make([]slog.Attr, len(h.attrs))
-		copy(h2.attrs, h.attrs)
-	}
-	return h2
+	h2 := *h
+	h2.unopenedGroups = make([]string, len(h.unopenedGroups)+1)
+	copy(h2.unopenedGroups, h.unopenedGroups)
+	h2.unopenedGroups[len(h2.unopenedGroups)-1] = name
+	return &h2
 }
 
 // slogToZerologLevel maps slog levels to zerolog levels.
@@ -140,73 +172,19 @@ func slogToZerologLevel(level slog.Level) Level {
 	}
 }
 
-// zerologToSlogLevel maps zerolog levels to slog levels.
-func zerologToSlogLevel(level Level) slog.Level {
-	switch level {
-	case TraceLevel:
-		return slog.LevelDebug - 4
-	case DebugLevel:
-		return slog.LevelDebug
-	case InfoLevel:
-		return slog.LevelInfo
-	case WarnLevel:
-		return slog.LevelWarn
-	case ErrorLevel:
-		return slog.LevelError
-	case FatalLevel:
-		return slog.LevelError + 4
-	case PanicLevel:
-		return slog.LevelError + 8
-	default:
-		return slog.LevelInfo
-	}
-}
-
-// joinPrefix concatenates a prefix and key with a dot separator.
-// It avoids allocations when either prefix or key is empty.
-func joinPrefix(prefix, key string) string {
-	if prefix == "" {
-		return key
-	}
-	if key == "" {
-		return prefix
-	}
-	return prefix + "." + key
-}
-
-// appendSlogAttr appends a single slog.Attr to the zerolog event, handling
-// type-specific encoding to avoid reflection where possible.
-func appendSlogAttr(event *Event, attr slog.Attr, prefix string) *Event {
+// appendSlogAttrToEvent appends a single slog.Attr to the zerolog event, handling type-specific encoding to avoid reflection where possible.
+func appendSlogAttrToEvent(event *Event, attr slog.Attr) *Event {
 	if event == nil {
 		return event
 	}
 
-	// Resolve the attribute to handle LogValuer types.
-	// This handles slog.KindLogValuer implicitly by unwrapping
-	// any values that implement slog.LogValuer to their resolved form.
 	attr.Value = attr.Value.Resolve()
-
-	// For group kinds, handle grouping before key concatenation
-	if attr.Value.Kind() == slog.KindGroup {
-		attrs := attr.Value.Group()
-		if len(attrs) == 0 {
-			return event
-		}
-		groupPrefix := joinPrefix(prefix, attr.Key)
-		for _, ga := range attrs {
-			event = appendSlogAttr(event, ga, groupPrefix)
-		}
+	if attr.Equal(slog.Attr{}) {
 		return event
 	}
 
-	// Skip empty keys for non-group attributes
-	if attr.Key == "" {
-		return event
-	}
-
-	key := joinPrefix(prefix, attr.Key)
+	key := attr.Key
 	val := attr.Value
-
 	switch val.Kind() {
 	case slog.KindString:
 		event = event.Str(key, val.String())
@@ -222,17 +200,70 @@ func appendSlogAttr(event *Event, attr slog.Attr, prefix string) *Event {
 		event = event.Dur(key, val.Duration())
 	case slog.KindTime:
 		event = event.Time(key, val.Time())
+	case slog.KindGroup:
+		attrs := val.Group()
+		if len(attrs) > 0 {
+			if key == "" {
+				for _, ga := range attrs {
+					event = appendSlogAttrToEvent(event, ga)
+				}
+			} else {
+				dict := event.CreateDict()
+				for _, ga := range attrs {
+					dict = appendSlogAttrToEvent(dict, ga)
+				}
+				event = event.Dict(key, dict)
+			}
+		}
 	case slog.KindAny:
 		v := val.Any()
 		switch cv := v.(type) {
+		case []time.Duration:
+			event = event.Durs(key, cv)
+		case net.IP:
+			event = event.IPAddr(key, cv)
+		case []net.IP:
+			event = event.IPAddrs(key, cv)
+		case net.IPNet:
+			event = event.IPPrefix(key, cv)
+		case []net.IPNet:
+			event = event.IPPrefixes(key, cv)
+		case net.HardwareAddr:
+			event = event.MACAddr(key, cv)
+		case []time.Time:
+			event = event.Times(key, cv)
 		case error:
 			event = event.AnErr(key, cv)
-		case time.Duration:
-			event = event.Dur(key, cv)
-		case time.Time:
-			event = event.Time(key, cv)
+		case []bool:
+			event = event.Bools(key, cv)
 		case []byte:
 			event = event.Bytes(key, cv)
+		case []error:
+			event = event.Errs(key, cv)
+		case []float32:
+			event = event.Floats32(key, cv)
+		case []float64:
+			event = event.Floats64(key, cv)
+		case []int:
+			event = event.Ints(key, cv)
+		case []int8:
+			event = event.Ints8(key, cv)
+		case []int16:
+			event = event.Ints16(key, cv)
+		case []int32:
+			event = event.Ints32(key, cv)
+		case []int64:
+			event = event.Ints64(key, cv)
+		case []string:
+			event = event.Strs(key, cv)
+		case []uint:
+			event = event.Uints(key, cv)
+		case []uint16:
+			event = event.Uints16(key, cv)
+		case []uint32:
+			event = event.Uints32(key, cv)
+		case []uint64:
+			event = event.Uints64(key, cv)
 		default:
 			event = event.Interface(key, v)
 		}
@@ -241,6 +272,105 @@ func appendSlogAttr(event *Event, attr slog.Attr, prefix string) *Event {
 	}
 
 	return event
+}
+
+func appendSlogAttrToContext(ctx Context, attr slog.Attr) Context {
+	attr.Value = attr.Value.Resolve()
+
+	if attr.Equal(slog.Attr{}) {
+		return ctx
+	}
+
+	key := attr.Key
+	val := attr.Value
+
+	switch val.Kind() {
+	case slog.KindString:
+		ctx = ctx.Str(key, val.String())
+	case slog.KindInt64:
+		ctx = ctx.Int64(key, val.Int64())
+	case slog.KindUint64:
+		ctx = ctx.Uint64(key, val.Uint64())
+	case slog.KindFloat64:
+		ctx = ctx.Float64(key, val.Float64())
+	case slog.KindBool:
+		ctx = ctx.Bool(key, val.Bool())
+	case slog.KindDuration:
+		ctx = ctx.Dur(key, val.Duration())
+	case slog.KindTime:
+		ctx = ctx.Time(key, val.Time())
+	case slog.KindGroup:
+		attrs := val.Group()
+		if len(attrs) > 0 {
+			if key == "" {
+				for _, ga := range attrs {
+					ctx = appendSlogAttrToContext(ctx, ga)
+				}
+			} else {
+				dict := ctx.CreateDict()
+				for _, ga := range attrs {
+					dict = appendSlogAttrToEvent(dict, ga)
+				}
+				ctx = ctx.Dict(key, dict)
+			}
+		}
+	case slog.KindAny:
+		v := val.Any()
+		switch cv := v.(type) {
+		case []time.Duration:
+			ctx = ctx.Durs(key, cv)
+		case net.IP:
+			ctx = ctx.IPAddr(key, cv)
+		case []net.IP:
+			ctx = ctx.IPAddrs(key, cv)
+		case net.IPNet:
+			ctx = ctx.IPPrefix(key, cv)
+		case []net.IPNet:
+			ctx = ctx.IPPrefixes(key, cv)
+		case net.HardwareAddr:
+			ctx = ctx.MACAddr(key, cv)
+		case []time.Time:
+			ctx = ctx.Times(key, cv)
+		case error:
+			ctx = ctx.AnErr(key, cv)
+		case []bool:
+			ctx = ctx.Bools(key, cv)
+		case []byte:
+			ctx = ctx.Bytes(key, cv)
+		case []error:
+			ctx = ctx.Errs(key, cv)
+		case []float32:
+			ctx = ctx.Floats32(key, cv)
+		case []float64:
+			ctx = ctx.Floats64(key, cv)
+		case []int:
+			ctx = ctx.Ints(key, cv)
+		case []int8:
+			ctx = ctx.Ints8(key, cv)
+		case []int16:
+			ctx = ctx.Ints16(key, cv)
+		case []int32:
+			ctx = ctx.Ints32(key, cv)
+		case []int64:
+			ctx = ctx.Ints64(key, cv)
+		case []string:
+			ctx = ctx.Strs(key, cv)
+		case []uint:
+			ctx = ctx.Uints(key, cv)
+		case []uint16:
+			ctx = ctx.Uints16(key, cv)
+		case []uint32:
+			ctx = ctx.Uints32(key, cv)
+		case []uint64:
+			ctx = ctx.Uints64(key, cv)
+		default:
+			ctx = ctx.Interface(key, v)
+		}
+	default:
+		ctx = ctx.Interface(key, val.Any())
+	}
+
+	return ctx
 }
 
 // Verify at compile time that SlogHandler satisfies the slog.Handler interface.

--- a/slog_test.go
+++ b/slog_test.go
@@ -180,21 +180,6 @@ func TestSlogHandler_Timestamp(t *testing.T) {
 		}
 	})
 
-	t.Run("custom TimeFieldFormat", func(t *testing.T) {
-		origTimeFieldFormat := TimeFieldFormat
-		TimeFieldFormat = TimeFormatUnix
-		t.Cleanup(func() { TimeFieldFormat = origTimeFieldFormat })
-		out := &bytes.Buffer{}
-		h := NewSlogHandler(New(out).With().Timestamp().Logger())
-		record := slog.NewRecord(time.Date(2001, time.February, 3, 4, 5, 6, 7, time.UTC), slog.LevelInfo, "msg", 0)
-		if err := h.Handle(context.Background(), record); err != nil {
-			t.Fatal(err)
-		}
-		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","time":981173106,"message":"msg"}`+"\n"; got != want {
-			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
-		}
-	})
-
 	t.Run("custom TimestampFieldName", func(t *testing.T) {
 		origTimestampFieldName := TimestampFieldName
 		TimestampFieldName = "t"

--- a/slog_test.go
+++ b/slog_test.go
@@ -680,7 +680,7 @@ func TestSlogHandler_ConcurrentLogs(t *testing.T) {
 	}
 }
 
-func TestSlogtest(t *testing.T) {
+func TestSlogHandler_Slogtest(t *testing.T) {
 	origMessageFieldName := MessageFieldName
 	origCallerFieldName := CallerFieldName
 	origLevelFieldName := LevelFieldName

--- a/slog_test.go
+++ b/slog_test.go
@@ -1,559 +1,735 @@
-package zerolog_test
+package zerolog
 
 import (
-	"context"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
+	"net"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
+	"testing/slogtest"
 	"time"
-
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/internal/cbor"
 )
 
-func newSlogLogger(buf *bytes.Buffer) *slog.Logger {
-	zl := zerolog.New(buf)
-	return slog.New(zerolog.NewSlogHandler(zl))
-}
-
-// decodeOutput converts the buffer contents to a JSON string,
-// handling CBOR-encoded output when built with the binary_log tag.
-func decodeOutput(buf *bytes.Buffer) string {
-	p := buf.Bytes()
-	if len(p) == 0 || p[0] < 0x7F {
-		return buf.String()
-	}
-	return cbor.DecodeObjectToStr(p) + "\n"
-}
-
-func decodeJSON(t *testing.T, buf *bytes.Buffer) map[string]interface{} {
-	t.Helper()
-	var m map[string]interface{}
-	s := decodeOutput(buf)
-	if err := json.Unmarshal([]byte(s), &m); err != nil {
-		t.Fatalf("failed to decode JSON %q: %v", s, err)
-	}
-	return m
-}
-
-func TestSlogHandler_BasicInfo(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("hello world")
-
-	m := decodeJSON(t, &buf)
-	if m["level"] != "info" {
-		t.Errorf("expected level info, got %v", m["level"])
-	}
-	if m["message"] != "hello world" {
-		t.Errorf("expected message 'hello world', got %v", m["message"])
-	}
-}
-
-func TestSlogHandler_Debug(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf).Level(zerolog.DebugLevel)
-	logger := slog.New(zerolog.NewSlogHandler(zl))
-
-	logger.Debug("debug msg")
-
-	m := decodeJSON(t, &buf)
-	if m["level"] != "debug" {
-		t.Errorf("expected level debug, got %v", m["level"])
-	}
-	if m["message"] != "debug msg" {
-		t.Errorf("expected message 'debug msg', got %v", m["message"])
-	}
-}
-
-func TestSlogHandler_Warn(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Warn("warn msg")
-
-	m := decodeJSON(t, &buf)
-	if m["level"] != "warn" {
-		t.Errorf("expected level warn, got %v", m["level"])
-	}
-}
-
-func TestSlogHandler_Error(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Error("error msg")
-
-	m := decodeJSON(t, &buf)
-	if m["level"] != "error" {
-		t.Errorf("expected level error, got %v", m["level"])
-	}
-}
-
-func TestSlogHandler_WithStringAttr(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("test", "key", "value")
-
-	m := decodeJSON(t, &buf)
-	if m["key"] != "value" {
-		t.Errorf("expected key=value, got %v", m["key"])
-	}
-}
-
-func TestSlogHandler_WithIntAttr(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("test", slog.Int("count", 42))
-
-	m := decodeJSON(t, &buf)
-	if m["count"] != float64(42) {
-		t.Errorf("expected count=42, got %v", m["count"])
-	}
-}
-
-func TestSlogHandler_WithBoolAttr(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("test", slog.Bool("flag", true))
-
-	m := decodeJSON(t, &buf)
-	if m["flag"] != true {
-		t.Errorf("expected flag=true, got %v", m["flag"])
-	}
-}
-
-func TestSlogHandler_WithFloat64Attr(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("test", slog.Float64("pi", 3.14))
-
-	m := decodeJSON(t, &buf)
-	if m["pi"] != 3.14 {
-		t.Errorf("expected pi=3.14, got %v", m["pi"])
-	}
-}
-
-func TestSlogHandler_WithTimeAttr(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	ts := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
-	logger.Info("test", slog.Time("created", ts))
-
-	m := decodeJSON(t, &buf)
-	if m["created"] == nil {
-		t.Error("expected created field to be present")
-	}
-}
-
-func TestSlogHandler_WithDurationAttr(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("test", slog.Duration("elapsed", 5*time.Second))
-
-	m := decodeJSON(t, &buf)
-	if m["elapsed"] == nil {
-		t.Error("expected elapsed field to be present")
-	}
-}
-
-func TestSlogHandler_WithErrorAttr(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("test", slog.Any("err", errors.New("something failed")))
-
-	m := decodeJSON(t, &buf)
-	if m["err"] != "something failed" {
-		t.Errorf("expected err='something failed', got %v", m["err"])
-	}
-}
-
-func TestSlogHandler_WithAttrs(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf)
-	handler := zerolog.NewSlogHandler(zl)
-
-	child := handler.WithAttrs([]slog.Attr{
-		slog.String("component", "auth"),
-		slog.Int("version", 2),
+func TestNewSlogHandler(t *testing.T) {
+	t.Run("no hooks", func(t *testing.T) {
+		h := NewSlogHandler(New(io.Discard))
+		if h.hasTimestampHook {
+			t.Error("hasTimestampHook, got: true, want: false")
+		}
+		if h.hasCallerHook {
+			t.Error("hasCallerHook, got: true, want: false")
+		}
+		if got, want := len(h.logger.hooks), 0; got != want {
+			t.Errorf("hooks len, got: %d, want: %d", got, want)
+		}
 	})
-	logger := slog.New(child)
 
-	logger.Info("request handled")
-
-	m := decodeJSON(t, &buf)
-	if m["component"] != "auth" {
-		t.Errorf("expected component=auth, got %v", m["component"])
-	}
-	if m["version"] != float64(2) {
-		t.Errorf("expected version=2, got %v", m["version"])
-	}
-	if m["message"] != "request handled" {
-		t.Errorf("expected message 'request handled', got %v", m["message"])
-	}
-}
-
-func TestSlogHandler_WithAttrsEmpty(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf)
-	handler := zerolog.NewSlogHandler(zl)
-
-	// WithAttrs with empty slice should return same handler
-	child := handler.WithAttrs(nil)
-	if child != handler {
-		t.Error("expected WithAttrs(nil) to return same handler")
-	}
-}
-
-func TestSlogHandler_WithGroup(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf)
-	handler := zerolog.NewSlogHandler(zl)
-
-	child := handler.WithGroup("request")
-	logger := slog.New(child)
-
-	logger.Info("handled", "method", "GET", "status", 200)
-
-	m := decodeJSON(t, &buf)
-	if m["request.method"] != "GET" {
-		t.Errorf("expected request.method=GET, got %v", m["request.method"])
-	}
-	if m["request.status"] != float64(200) {
-		t.Errorf("expected request.status=200, got %v", m["request.status"])
-	}
-}
-
-func TestSlogHandler_WithGroupEmpty(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf)
-	handler := zerolog.NewSlogHandler(zl)
-
-	// WithGroup with empty name should return same handler
-	child := handler.WithGroup("")
-	if child != handler {
-		t.Error("expected WithGroup('') to return same handler")
-	}
-}
-
-func TestSlogHandler_WithNestedGroups(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf)
-	handler := zerolog.NewSlogHandler(zl)
-
-	child := handler.WithGroup("http").WithGroup("request")
-	logger := slog.New(child)
-
-	logger.Info("handled", "method", "POST")
-
-	m := decodeJSON(t, &buf)
-	if m["http.request.method"] != "POST" {
-		t.Errorf("expected http.request.method=POST, got %v", m["http.request.method"])
-	}
-}
-
-func TestSlogHandler_WithGroupAndAttrs(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf)
-	handler := zerolog.NewSlogHandler(zl)
-
-	child := handler.WithGroup("server").WithAttrs([]slog.Attr{
-		slog.String("host", "localhost"),
+	t.Run("timestamp hook stripped", func(t *testing.T) {
+		h := NewSlogHandler(New(io.Discard).With().Timestamp().Logger())
+		if !h.hasTimestampHook {
+			t.Error("hasTimestampHook, got: false, want: true")
+		}
+		if got, want := len(h.logger.hooks), 0; got != want {
+			t.Errorf("hooks len, got: %d, want: %d", got, want)
+		}
 	})
-	logger := slog.New(child)
 
-	logger.Info("started", "port", 8080)
+	t.Run("caller hook stripped", func(t *testing.T) {
+		h := NewSlogHandler(New(io.Discard).With().Caller().Logger())
+		if !h.hasCallerHook {
+			t.Error("hasCallerHook, got: false, want: true")
+		}
+		if got, want := len(h.logger.hooks), 0; got != want {
+			t.Errorf("hooks len, got: %d, want: %d", got, want)
+		}
+	})
 
-	m := decodeJSON(t, &buf)
-	if m["server.host"] != "localhost" {
-		t.Errorf("expected server.host=localhost, got %v", m["server.host"])
+	t.Run("other hooks preserved", func(t *testing.T) {
+		logger := New(io.Discard).With().Timestamp().Caller().Logger().Hook(HookFunc(func(e *Event, level Level, msg string) {}))
+		h := NewSlogHandler(logger)
+		if !h.hasTimestampHook {
+			t.Error("hasTimestampHook, got: false, want: true")
+		}
+		if !h.hasCallerHook {
+			t.Error("hasCallerHook, got: false, want: true")
+		}
+		if got, want := len(h.logger.hooks), 1; got != want {
+			t.Errorf("hooks len, got: %d, want: %d", got, want)
+		}
+	})
+
+	t.Run("original logger not mutated", func(t *testing.T) {
+		logger := New(io.Discard).With().Timestamp().Caller().Logger()
+		before := len(logger.hooks)
+		NewSlogHandler(logger)
+		if got, want := len(logger.hooks), before; got != want {
+			t.Errorf("original logger hooks mutated, got: %d, want: %d", got, want)
+		}
+	})
+}
+
+func TestSlogHandler_Enabled(t *testing.T) {
+	origGlobalLevel := GlobalLevel()
+	SetGlobalLevel(DebugLevel)
+	t.Cleanup(func() {
+		SetGlobalLevel(origGlobalLevel)
+	})
+
+	tests := []struct {
+		name        string
+		loggerLevel Level
+		level       slog.Level
+		want        bool
+	}{
+		{"InfoLevel/slog.LevelInfo", InfoLevel, slog.LevelInfo, true},
+		{"InfoLevel/slog.LevelDebug", InfoLevel, slog.LevelDebug, false},
+		{"InfoLevel/slog.LevelWarn", InfoLevel, slog.LevelWarn, true},
+		{"InfoLevel/slog.LevelInfo-1", InfoLevel, slog.LevelInfo - 1, false},
+		{"InfoLevel/slog.LevelInfo+1", InfoLevel, slog.LevelInfo + 1, true},
+		{"Disabled/slog.LevelDebug", Disabled, slog.LevelDebug, false},
+		{"Disabled/slog.LevelInfo", Disabled, slog.LevelInfo, false},
+		{"Disabled/slog.LevelWarn", Disabled, slog.LevelWarn, false},
+		{"Disabled/slog.LevelError", Disabled, slog.LevelError, false},
+		{"Global_DebugLevel/TraceLevel/slog.LevelDebug-2", TraceLevel, slog.LevelDebug - 2, false},
 	}
-	if m["server.port"] != float64(8080) {
-		t.Errorf("expected server.port=8080, got %v", m["server.port"])
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewSlogHandler(New(io.Discard).Level(tt.loggerLevel))
+			if got, want := h.Enabled(context.Background(), tt.level), tt.want; got != want {
+				t.Errorf("SlogHandler.Enabled, got: %v, want: %v", got, want)
+			}
+		})
 	}
 }
 
-func TestSlogHandler_GroupAttrInRecord(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("test", slog.Group("user",
-		slog.String("name", "alice"),
-		slog.Int("age", 30),
-	))
-
-	m := decodeJSON(t, &buf)
-	if m["user.name"] != "alice" {
-		t.Errorf("expected user.name=alice, got %v", m["user.name"])
-	}
-	if m["user.age"] != float64(30) {
-		t.Errorf("expected user.age=30, got %v", m["user.age"])
-	}
-}
-
-func TestSlogHandler_LevelFiltering(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf).Level(zerolog.WarnLevel)
-	handler := zerolog.NewSlogHandler(zl)
-
-	// Debug should be filtered
-	if handler.Enabled(nil, slog.LevelDebug) {
-		t.Error("expected debug to be filtered at warn level")
-	}
-	// Info should be filtered
-	if handler.Enabled(nil, slog.LevelInfo) {
-		t.Error("expected info to be filtered at warn level")
-	}
-	// Warn should pass
-	if !handler.Enabled(nil, slog.LevelWarn) {
-		t.Error("expected warn to be enabled at warn level")
-	}
-	// Error should pass
-	if !handler.Enabled(nil, slog.LevelError) {
-		t.Error("expected error to be enabled at warn level")
-	}
-}
-
-func TestSlogHandler_FilteredMessageNotWritten(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf).Level(zerolog.ErrorLevel)
-	logger := slog.New(zerolog.NewSlogHandler(zl))
-
-	logger.Info("should not appear")
-
-	if buf.Len() != 0 {
-		t.Errorf("expected no output for filtered message, got %q", buf.String())
-	}
-}
-
-func TestSlogHandler_MultipleAttrs(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("multi",
-		slog.String("a", "1"),
-		slog.Int("b", 2),
-		slog.Bool("c", true),
-		slog.Float64("d", 3.5),
-	)
-
-	m := decodeJSON(t, &buf)
-	if m["a"] != "1" {
-		t.Errorf("expected a=1, got %v", m["a"])
-	}
-	if m["b"] != float64(2) {
-		t.Errorf("expected b=2, got %v", m["b"])
-	}
-	if m["c"] != true {
-		t.Errorf("expected c=true, got %v", m["c"])
-	}
-	if m["d"] != 3.5 {
-		t.Errorf("expected d=3.5, got %v", m["d"])
-	}
-}
-
-func TestSlogHandler_LogValuer(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("test", "addr", testLogValuer{host: "example.com", port: 443})
-
-	m := decodeJSON(t, &buf)
-	// LogValuer resolves to a group
-	if m["addr.host"] != "example.com" {
-		t.Errorf("expected addr.host=example.com, got %v", m["addr.host"])
-	}
-	if m["addr.port"] != float64(443) {
-		t.Errorf("expected addr.port=443, got %v", m["addr.port"])
-	}
-}
-
-type testLogValuer struct {
-	host string
-	port int
-}
-
-func (v testLogValuer) LogValue() slog.Value {
-	return slog.GroupValue(
-		slog.String("host", v.host),
-		slog.Int("port", v.port),
-	)
-}
-
-func TestSlogHandler_WithAttrsImmutability(t *testing.T) {
-	var buf1, buf2 bytes.Buffer
-	zl1 := zerolog.New(&buf1)
-	zl2 := zerolog.New(&buf2)
-
-	handler := zerolog.NewSlogHandler(zl1)
-	child1 := handler.WithAttrs([]slog.Attr{slog.String("from", "child1")})
-	_ = zerolog.NewSlogHandler(zl2).WithAttrs([]slog.Attr{slog.String("from", "child2")})
-
-	slog.New(child1).Info("test")
-
-	m := decodeJSON(t, &buf1)
-	if m["from"] != "child1" {
-		t.Errorf("expected from=child1, got %v", m["from"])
+func TestSlogHandler_EnabledNilWriter(t *testing.T) {
+	h := NewSlogHandler(Logger{})
+	if got, want := h.Enabled(context.Background(), slog.LevelError), false; got != want {
+		t.Errorf("SlogHandler.Enabled, got: %v, want: %v", got, want)
 	}
 }
 
 func TestSlogHandler_LevelMapping(t *testing.T) {
 	tests := []struct {
-		slogLevel slog.Level
-		wantLevel string
+		name  string
+		level slog.Level
+		want  string
 	}{
-		{slog.LevelDebug - 4, "trace"},
-		{slog.LevelDebug, "debug"},
-		{slog.LevelInfo, "info"},
-		{slog.LevelWarn, "warn"},
-		{slog.LevelError, "error"},
+		{"below debug", slog.LevelDebug - 2, `{"level":"trace","message":"msg"}` + "\n"},
+		{"debug", slog.LevelDebug, `{"level":"debug","message":"msg"}` + "\n"},
+		{"between debug and info", slog.LevelInfo - 2, `{"level":"debug","message":"msg"}` + "\n"},
+		{"info", slog.LevelInfo, `{"level":"info","message":"msg"}` + "\n"},
+		{"between info and warn", slog.LevelWarn - 2, `{"level":"info","message":"msg"}` + "\n"},
+		{"warn", slog.LevelWarn, `{"level":"warn","message":"msg"}` + "\n"},
+		{"between warn and error", slog.LevelError - 2, `{"level":"warn","message":"msg"}` + "\n"},
+		{"error", slog.LevelError, `{"level":"error","message":"msg"}` + "\n"},
+		{"above error", slog.LevelError + 2, `{"level":"error","message":"msg"}` + "\n"},
 	}
 
 	for _, tt := range tests {
-		var buf bytes.Buffer
-		zl := zerolog.New(&buf).Level(zerolog.TraceLevel)
-		logger := slog.New(zerolog.NewSlogHandler(zl))
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			logger := slog.New(NewSlogHandler(New(out)))
+			logger.Log(context.Background(), tt.level, "msg")
+			if got, want := decodeIfBinaryToString(out.Bytes()), tt.want; got != want {
+				t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+			}
+		})
+	}
+}
 
-		logger.Log(nil, tt.slogLevel, "test")
-
-		m := decodeJSON(t, &buf)
-		if m["level"] != tt.wantLevel {
-			t.Errorf("slog level %d: expected zerolog level %q, got %q",
-				tt.slogLevel, tt.wantLevel, m["level"])
+func TestSlogHandler_Timestamp(t *testing.T) {
+	t.Run("no timestamp hook omits timestamp field", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out)))
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 		}
-		buf.Reset()
-	}
-}
-
-func TestSlogHandler_EmptyMessage(t *testing.T) {
-	var buf bytes.Buffer
-	logger := newSlogLogger(&buf)
-
-	logger.Info("", "key", "val")
-
-	m := decodeJSON(t, &buf)
-	if m["key"] != "val" {
-		t.Errorf("expected key=val, got %v", m["key"])
-	}
-}
-
-func TestSlogHandler_WithContext(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf).With().Str("service", "api").Logger()
-	logger := slog.New(zerolog.NewSlogHandler(zl))
-
-	logger.Info("request")
-
-	m := decodeJSON(t, &buf)
-	if m["service"] != "api" {
-		t.Errorf("expected service=api, got %v", m["service"])
-	}
-	if m["message"] != "request" {
-		t.Errorf("expected message 'request', got %v", m["message"])
-	}
-}
-
-func TestSlogHandler_EnabledRespectsGlobalLevel(t *testing.T) {
-	var buf bytes.Buffer
-	zl := zerolog.New(&buf).Level(zerolog.DebugLevel)
-	handler := zerolog.NewSlogHandler(zl)
-
-	// Logger level is debug, so info should be enabled
-	if !handler.Enabled(nil, slog.LevelInfo) {
-		t.Fatal("expected info to be enabled before setting global level")
-	}
-
-	// Set global level to error
-	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
-	defer zerolog.SetGlobalLevel(zerolog.TraceLevel)
-
-	// Now info should be disabled even though logger level allows it
-	if handler.Enabled(nil, slog.LevelInfo) {
-		t.Error("expected info to be disabled when GlobalLevel is error")
-	}
-	// Error should still be enabled
-	if !handler.Enabled(nil, slog.LevelError) {
-		t.Error("expected error to be enabled when GlobalLevel is error")
-	}
-}
-
-func TestSlogHandler_EnabledNilWriter(t *testing.T) {
-	zl := zerolog.Nop()
-	handler := zerolog.NewSlogHandler(zl)
-
-	if handler.Enabled(nil, slog.LevelError) {
-		t.Error("expected disabled for nop logger")
-	}
-}
-
-func TestSlogHandler_HandlePropagatesContext(t *testing.T) {
-	var buf bytes.Buffer
-	type ctxKey struct{}
-	ctx := context.WithValue(context.Background(), ctxKey{}, "test-value")
-
-	var gotCtx context.Context
-	hook := zerolog.HookFunc(func(e *zerolog.Event, level zerolog.Level, msg string) {
-		gotCtx = e.GetCtx()
 	})
 
-	zl := zerolog.New(&buf).Hook(hook)
-	handler := zerolog.NewSlogHandler(zl)
-
-	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
-	_ = handler.Handle(ctx, record)
-
-	if gotCtx == nil {
-		t.Fatal("expected context to be propagated to event")
-	}
-	if gotCtx.Value(ctxKey{}) != "test-value" {
-		t.Error("expected context value to be preserved")
-	}
-}
-
-func TestSlogHandler_NoDuplicateTimestamp(t *testing.T) {
-	var buf bytes.Buffer
-	// Create logger with Timestamp() hook - this adds "time" automatically
-	zl := zerolog.New(&buf).With().Timestamp().Logger()
-	handler := zerolog.NewSlogHandler(zl)
-
-	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
-	_ = handler.Handle(context.Background(), record)
-
-	output := decodeOutput(&buf)
-	// Count occurrences of the timestamp field name - should appear exactly once
-	count := 0
-	for i := 0; i < len(output); i++ {
-		if i+4 <= len(output) && output[i:i+4] == "time" {
-			count++
+	t.Run("zero time omits timestamp field", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		h := NewSlogHandler(New(out).With().Timestamp().Logger())
+		record := slog.NewRecord(time.Time{}, slog.LevelInfo, "msg", 0)
+		if err := h.Handle(context.Background(), record); err != nil {
+			t.Fatal(err)
 		}
-	}
-	if count > 1 {
-		t.Errorf("expected at most 1 timestamp field, got %d in output: %s", count, output)
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("timestamp field logged from record.Time", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		h := NewSlogHandler(New(out).With().Timestamp().Logger())
+		record := slog.NewRecord(time.Date(2001, time.February, 3, 4, 5, 6, 7, time.UTC), slog.LevelInfo, "msg", 0)
+		if err := h.Handle(context.Background(), record); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","time":"2001-02-03T04:05:06Z","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("custom TimeFieldFormat", func(t *testing.T) {
+		origTimeFieldFormat := TimeFieldFormat
+		TimeFieldFormat = TimeFormatUnix
+		t.Cleanup(func() { TimeFieldFormat = origTimeFieldFormat })
+		out := &bytes.Buffer{}
+		h := NewSlogHandler(New(out).With().Timestamp().Logger())
+		record := slog.NewRecord(time.Date(2001, time.February, 3, 4, 5, 6, 7, time.UTC), slog.LevelInfo, "msg", 0)
+		if err := h.Handle(context.Background(), record); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","time":981173106,"message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("custom TimestampFieldName", func(t *testing.T) {
+		origTimestampFieldName := TimestampFieldName
+		TimestampFieldName = "t"
+		t.Cleanup(func() { TimestampFieldName = origTimestampFieldName })
+		out := &bytes.Buffer{}
+		h := NewSlogHandler(New(out).With().Timestamp().Logger())
+		record := slog.NewRecord(time.Date(2001, time.February, 3, 4, 5, 6, 7, time.UTC), slog.LevelInfo, "msg", 0)
+		if err := h.Handle(context.Background(), record); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","t":"2001-02-03T04:05:06Z","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+}
+
+func TestSlogHandler_Caller(t *testing.T) {
+	t.Run("no caller hook omits caller field", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out)))
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("zero PC omits caller field", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		h := NewSlogHandler(New(out).With().Caller().Logger())
+		record := slog.NewRecord(time.Time{}, slog.LevelInfo, "msg", 0)
+		if err := h.Handle(context.Background(), record); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("caller field resolves from record.PC", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out).With().Caller().Logger()))
+		pc, file, line, _ := runtime.Caller(0)
+		caller := CallerMarshalFunc(pc, file, line+2)
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","caller":"`+caller+`","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("custom CallerMarshalFunc", func(t *testing.T) {
+		origCallerMarshalFunc := CallerMarshalFunc
+		CallerMarshalFunc = func(pc uintptr, file string, line int) string {
+			parts := strings.Split(file, "/")
+			if len(parts) > 1 {
+				return strings.Join(parts[len(parts)-2:], "/") + ":" + strconv.Itoa(line)
+			}
+
+			return runtime.FuncForPC(pc).Name() + ":" + file + ":" + strconv.Itoa(line)
+		}
+		t.Cleanup(func() { CallerMarshalFunc = origCallerMarshalFunc })
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out).With().Caller().Logger()))
+		pc, file, line, _ := runtime.Caller(0)
+		caller := CallerMarshalFunc(pc, file, line+2)
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","caller":"`+caller+`","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("custom CallerFieldName", func(t *testing.T) {
+		origCallerFieldName := CallerFieldName
+		CallerFieldName = "source"
+		t.Cleanup(func() { CallerFieldName = origCallerFieldName })
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out).With().Caller().Logger()))
+		pc, file, line, _ := runtime.Caller(0)
+		caller := CallerMarshalFunc(pc, file, line+2)
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","source":"`+caller+`","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+}
+
+func TestSlogHandler_Message(t *testing.T) {
+	t.Run("empty message omits message field", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out)))
+		logger.Info("")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("logs message field", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out)))
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("custom MessageFieldName", func(t *testing.T) {
+		origMessageFieldName := MessageFieldName
+		MessageFieldName = "msg"
+		t.Cleanup(func() { MessageFieldName = origMessageFieldName })
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out)))
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","msg":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+}
+
+type testCtxKey struct{}
+
+func TestSlogHandler_PropagatesContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), testCtxKey{}, "v")
+
+	hook := HookFunc(func(e *Event, level Level, message string) {
+		ctx := e.GetCtx()
+		if ctx == nil {
+			return
+		}
+		if v, ok := ctx.Value(testCtxKey{}).(string); ok {
+			e.Str("k", v)
+		}
+	})
+
+	out := &bytes.Buffer{}
+	logger := slog.New(NewSlogHandler(New(out).Hook(hook)))
+	logger.InfoContext(ctx, "msg")
+	if got, want := decodeIfBinaryToString(out.Bytes()),
+		`{"level":"info","k":"v","message":"msg"}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
 }
 
-func TestSlogHandler_TimestampWithoutHook(t *testing.T) {
-	var buf bytes.Buffer
-	// Logger without Timestamp() hook - Handle should add the timestamp
-	zl := zerolog.New(&buf)
-	handler := zerolog.NewSlogHandler(zl)
+type testLogValuer struct {
+	v any
+}
 
-	ts := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
-	record := slog.NewRecord(ts, slog.LevelInfo, "test", 0)
-	_ = handler.Handle(context.Background(), record)
+func (t testLogValuer) LogValue() slog.Value { return slog.AnyValue(t.v) }
 
-	m := decodeJSON(t, &buf)
-	if m[zerolog.TimestampFieldName] == nil {
-		t.Error("expected timestamp field when logger has no timestamp hook")
+type testAny struct {
+	Name string `json:"name"`
+}
+
+func TestSlogHandler_AttrsTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		args []any
+		want string
+	}{
+		{"zero attr", []any{slog.Attr{}}, `{"level":"info","message":"msg"}` + "\n"},
+		{"empty key", []any{"", "v"}, `{"level":"info","":"v","message":"msg"}` + "\n"},
+		{"empty group", []any{slog.Group("g")}, `{"level":"info","message":"msg"}` + "\n"},
+		{"basic types", []any{
+			"string", "hello",
+			"int64", -1,
+			"uint64", uint64(1),
+			"float64", 3.14,
+			"bool", true,
+			"time", time.Date(2001, time.February, 3, 4, 5, 6, 7, time.UTC),
+			"duration", time.Second,
+		}, `{"level":"info","string":"hello","int64":-1,"uint64":1,"float64":3.14,"bool":true,"time":"2001-02-03T04:05:06Z","duration":1000,"message":"msg"}` + "\n"},
+		{"group", []any{slog.Group("g", "k", "v")}, `{"level":"info","g":{"k":"v"},"message":"msg"}` + "\n"},
+		{"empty group name", []any{slog.Group("", "k", "v")}, `{"level":"info","k":"v","message":"msg"}` + "\n"},
+		{"nested group", []any{slog.Group("g1", slog.Group("g2", "k", "v"))}, `{"level":"info","g1":{"g2":{"k":"v"}},"message":"msg"}` + "\n"},
+		{"slog.LogValuer", []any{"k", &testLogValuer{"v"}}, `{"level":"info","k":"v","message":"msg"}` + "\n"},
+		{"slog.LogValuer in group", []any{slog.Group("g", "k", &testLogValuer{"v"})}, `{"level":"info","g":{"k":"v"},"message":"msg"}` + "\n"},
+		{"any", []any{"user", testAny{Name: "john"}}, `{"level":"info","user":{"name":"john"},"message":"msg"}` + "\n"},
+		{"other types", []any{
+			"strs", []string{"one", "two"},
+			"ints", []int{-1, 2},
+			"ints8", []int8{-1, 2},
+			"ints16", []int16{-1, 2},
+			"ints32", []int32{-1, 2},
+			"ints64", []int64{-1, 2},
+			"uints", []uint{1, 2},
+			"uints16", []uint16{1, 2},
+			"uints32", []uint32{1, 2},
+			"uints64", []uint64{1, 2},
+			"floats32", []float32{3.14, 1.414},
+			"floats64", []float64{3.14, 1.414},
+			"bools", []bool{true, false},
+			"times", []time.Time{time.Date(2001, time.February, 3, 4, 5, 6, 7, time.UTC), time.Date(2002, time.February, 3, 4, 5, 6, 7, time.UTC)},
+			"durs", []time.Duration{time.Second, time.Minute},
+			"error", errors.New("test error"),
+			"errs", []error{errors.New("first error"), errors.New("second error")},
+			"bytes", []byte("foo"),
+			"ipAddr", net.IP{192, 168, 0, 10},
+			"ipAddrs", []net.IP{{192, 168, 0, 10}, {127, 0, 0, 0}},
+			"ipPrefix", net.IPNet{IP: net.IP{192, 168, 0, 10}, Mask: net.CIDRMask(24, 32)},
+			"ipPrefixes", []net.IPNet{{IP: net.IP{192, 168, 0, 10}, Mask: net.CIDRMask(24, 32)}, {IP: net.IP{127, 0, 0, 0}, Mask: net.CIDRMask(24, 32)}},
+			"macAddr", net.HardwareAddr{0x01, 0x23, 0x45, 0x67, 0x89, 0xab},
+		}, `{"level":"info","strs":["one","two"],"ints":[-1,2],"ints8":[-1,2],"ints16":[-1,2],"ints32":[-1,2],"ints64":[-1,2],"uints":[1,2],"uints16":[1,2],"uints32":[1,2],"uints64":[1,2],"floats32":[3.14,1.414],"floats64":[3.14,1.414],"bools":[true,false],"times":["2001-02-03T04:05:06Z","2002-02-03T04:05:06Z"],"durs":[1000,60000],"error":"test error","errs":["first error","second error"],"bytes":"foo","ipAddr":"192.168.0.10","ipAddrs":["192.168.0.10","127.0.0.0"],"ipPrefix":"192.168.0.10/24","ipPrefixes":["192.168.0.10/24","127.0.0.0/24"],"macAddr":"01:23:45:67:89:ab","message":"msg"}` + "\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run("RecordAttrs/"+tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			logger := slog.New(NewSlogHandler(New(out)))
+			logger.Info("msg", tt.args...)
+			if got, want := decodeIfBinaryToString(out.Bytes()), tt.want; got != want {
+				t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+			}
+		})
+
+		t.Run("WithAttrs/"+tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			logger := slog.New(NewSlogHandler(New(out))).With(tt.args...)
+			logger.Info("msg")
+			if got, want := decodeIfBinaryToString(out.Bytes()), tt.want; got != want {
+				t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+			}
+		})
+	}
+}
+
+func TestSlogHandler_WithGroup(t *testing.T) {
+	t.Run("empty name returns same handler", func(t *testing.T) {
+		h := NewSlogHandler(New(io.Discard))
+		if got := h.WithGroup(""); got != h {
+			t.Error("empty group name: expected same handler")
+		}
+	})
+
+	t.Run("original handler not mutated", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out)))
+		logger.WithGroup("g")
+		logger.Info("msg", "k", "v")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","k":"v","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("no attrs produces no group key", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out))).WithGroup("g")
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("no attrs produces no group key (multiple nested groups)", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out))).WithGroup("g1").WithGroup("g2")
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("record attrs nested under group", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out))).WithGroup("g")
+		logger.Info("msg", "k", "v")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","g":{"k":"v"},"message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("sibling groups", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		base := slog.New(NewSlogHandler(New(out)))
+		base.WithGroup("g1").Info("msg", "k", "v")
+		base.WithGroup("g2").Info("msg", "k", "v")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","g1":{"k":"v"},"message":"msg"}`+"\n"+`{"level":"info","g2":{"k":"v"},"message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("nested groups", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out))).WithGroup("g1").WithGroup("g2")
+		logger.Info("msg", "k", "v")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","g1":{"g2":{"k":"v"}},"message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+}
+
+func TestSlogHandler_WithAttrs(t *testing.T) {
+	t.Run("empty attrs returns same handler", func(t *testing.T) {
+		h := NewSlogHandler(New(io.Discard))
+		if got := h.WithAttrs(nil); got != h {
+			t.Error("nil attrs: expected same handler")
+		}
+		if got := h.WithAttrs([]slog.Attr{}); got != h {
+			t.Error("empty attrs: expected same handler")
+		}
+	})
+
+	t.Run("original handler not mutated", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out)))
+		logger.With("k", "v")
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("attrs applied to every record", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out))).With("k", "v")
+		logger.Info("first")
+		logger.Info("second")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","k":"v","message":"first"}`+"\n"+`{"level":"info","k":"v","message":"second"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("attrs accumulate across multiple calls", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out))).With("k1", "v1").With("k2", "v2")
+		logger.Info("msg")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","k1":"v1","k2":"v2","message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+}
+
+func TestSlogHandler_WithGroupAndAttrs(t *testing.T) {
+	t.Run("WithGroup/WithAttrs", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out))).WithGroup("g").With("a", "b")
+		logger.Info("msg", "k", "v")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","g":{"a":"b","k":"v"},"message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("WithAttrs/WithGroup", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out))).With("a", "b").WithGroup("g")
+		logger.Info("msg", "k", "v")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","a":"b","g":{"k":"v"},"message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("WithAttrs/WithGroup/WithAttrs", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out))).With("a", "b").WithGroup("g").With("c", "d")
+		logger.Info("msg", "k", "v")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","a":"b","g":{"c":"d","k":"v"},"message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("WithGroup/WithAttrs/WithGroup", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := slog.New(NewSlogHandler(New(out))).WithGroup("g1").With("a", "b").WithGroup("g2")
+		logger.Info("msg", "k", "v")
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","g1":{"a":"b","g2":{"k":"v"}},"message":"msg"}`+"\n"; got != want {
+			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+}
+
+func TestSlogHandler_WithSampler(t *testing.T) {
+	out := &bytes.Buffer{}
+	sampler := &BasicSampler{N: 2}
+	logger := slog.New(NewSlogHandler(New(out).Sample(sampler)))
+	logger.Info("msg", "i", 1)
+	logger.Info("msg", "i", 2)
+	logger.Info("msg", "i", 3)
+	logger.Info("msg", "i", 4)
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","i":1,"message":"msg"}`+"\n"+`{"level":"info","i":3,"message":"msg"}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestSlogHandler_WithZerologContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		group    string
+		withArgs []any
+		logArgs  []any
+		want     string
+	}{
+		{"Empty/Empty/Empty", "", nil, nil, `{"level":"info","k":"v","message":"msg"}` + "\n"},
+		{"Empty/Empty/Attrs", "", nil, []any{"k1", "v1"}, `{"level":"info","k":"v","k1":"v1","message":"msg"}` + "\n"},
+		{"Empty/WithAttrs/Empty", "", []any{"k1", "v1"}, nil, `{"level":"info","k":"v","k1":"v1","message":"msg"}` + "\n"},
+		{"Empty/WithAttrs/Attrs", "", []any{"k1", "v1"}, []any{"k2", "v2"}, `{"level":"info","k":"v","k1":"v1","k2":"v2","message":"msg"}` + "\n"},
+		{"Group/Empty/Empty", "g", nil, nil, `{"level":"info","k":"v","message":"msg"}` + "\n"},
+		{"Group/Empty/Attrs", "g", nil, []any{"k1", "v1"}, `{"level":"info","k":"v","g":{"k1":"v1"},"message":"msg"}` + "\n"},
+		{"Group/WithAttrs/Empty", "g", []any{"k1", "v1"}, nil, `{"level":"info","k":"v","g":{"k1":"v1"},"message":"msg"}` + "\n"},
+		{"Group/WithAttrs/Attrs", "g", []any{"k1", "v1"}, []any{"k2", "v2"}, `{"level":"info","k":"v","g":{"k1":"v1","k2":"v2"},"message":"msg"}` + "\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			logger := slog.New(NewSlogHandler(New(out).With().Str("k", "v").Logger())).WithGroup(tt.group).With(tt.withArgs...)
+			logger.Info("msg", tt.logArgs...)
+			if got, want := decodeIfBinaryToString(out.Bytes()), tt.want; got != want {
+				t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+			}
+		})
+	}
+}
+
+func TestSlogHandler_WithHook(t *testing.T) {
+	called := false
+	hook := HookFunc(func(e *Event, level Level, msg string) {
+		called = true
+	})
+	logger := slog.New(NewSlogHandler(New(io.Discard).Hook(hook)))
+	logger.Info("msg")
+	if !called {
+		t.Error("called, got: false, want: true")
+	}
+}
+
+// Run a few different loggers with concurrent logs
+// in an attempt to trip up 'go test -race' and discover any data races.
+//
+// Adopted from :- https://github.com/uber-go/zap/blob/018b91390e74732e9e40f8d356887b8d06461886/exp/zapslog/handler_test.go#L271
+func TestSlogHandler_ConcurrentLogs(t *testing.T) {
+	t.Parallel()
+
+	workers := 100
+	logs := 10
+
+	tests := []struct {
+		name string
+		log  func(*slog.Logger)
+	}{
+		{
+			name: "default",
+			log: func(l *slog.Logger) {
+				l.Info("default", "k", "v")
+			},
+		},
+		{
+			name: "WithGroup",
+			log: func(l *slog.Logger) {
+				l.WithGroup("g").Info("with group", "k", "v")
+			},
+		},
+		{
+			name: "WithAttrs",
+			log: func(l *slog.Logger) {
+				l.With("a", "b").Info("with attrs", "k", "v")
+			},
+		},
+		{
+			name: "WithGroupAndAttrs",
+			log: func(l *slog.Logger) {
+				l.WithGroup("g").With("a", "b").Info("with group and attrs", "k", "v")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out := &bytes.Buffer{}
+			logger := slog.New(NewSlogHandler(New(SyncWriter(out)).With().Timestamp().Caller().Str("x", "y").Logger()))
+
+			// Use two wait groups to coordinate the workers:
+			//
+			// - ready: indicates when all workers should start logging.
+			// - done: indicates when all workers have finished logging.
+			var ready, done sync.WaitGroup
+
+			ready.Add(workers)
+			done.Add(workers)
+			for range workers {
+				go func() {
+					defer done.Done()
+
+					ready.Done() // I'm ready.
+					ready.Wait() // Are others?
+
+					for range logs {
+						tt.log(logger)
+					}
+				}()
+			}
+
+			done.Wait()
+
+			if got, want := strings.Count(decodeIfBinaryToString(out.Bytes()), "\n"), workers*logs; got != want {
+				t.Errorf("number of logs, got: %d, want: %d", got, want)
+			}
+		})
+	}
+}
+
+func TestSlogtest(t *testing.T) {
+	origMessageFieldName := MessageFieldName
+	origCallerFieldName := CallerFieldName
+	origLevelFieldName := LevelFieldName
+	origTimestampFieldName := TimestampFieldName
+
+	// Set field names as expected by slogtest
+	MessageFieldName = slog.MessageKey
+	CallerFieldName = slog.SourceKey
+	LevelFieldName = slog.LevelKey
+	TimestampFieldName = slog.TimeKey
+
+	t.Cleanup(func() {
+		MessageFieldName = origMessageFieldName
+		CallerFieldName = origCallerFieldName
+		LevelFieldName = origLevelFieldName
+		TimestampFieldName = origTimestampFieldName
+	})
+
+	out := &bytes.Buffer{}
+	handler := NewSlogHandler(New(out).With().Timestamp().Caller().Logger())
+
+	if err := slogtest.TestHandler(
+		handler,
+		func() []map[string]any {
+			var entries []map[string]any
+			dec := json.NewDecoder(bytes.NewReader(decodeIfBinaryToBytes(out.Bytes())))
+			for dec.More() {
+				var decoded map[string]any
+				if err := dec.Decode(&decoded); err != nil {
+					t.Fatal(err)
+				}
+				entries = append(entries, decoded)
+			}
+			return entries
+		},
+	); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/slog_test.go
+++ b/slog_test.go
@@ -624,35 +624,37 @@ func TestSlogHandler_WithHook(t *testing.T) {
 func TestSlogHandler_ConcurrentLogs(t *testing.T) {
 	t.Parallel()
 
-	workers := 100
-	logs := 10
+	const (
+		NumWorkers = 10
+		NumLogs    = 100
+	)
 
 	tests := []struct {
 		name string
-		log  func(*slog.Logger)
+		log  func(l *slog.Logger, worker, log int)
 	}{
 		{
 			name: "default",
-			log: func(l *slog.Logger) {
-				l.Info("default", "k", "v")
+			log: func(l *slog.Logger, worker, log int) {
+				l.Info("default", "worker", worker, "log", log)
 			},
 		},
 		{
 			name: "WithGroup",
-			log: func(l *slog.Logger) {
-				l.WithGroup("g").Info("with group", "k", "v")
+			log: func(l *slog.Logger, worker, log int) {
+				l.WithGroup("g").Info("with group", "worker", worker, "log", log)
 			},
 		},
 		{
 			name: "WithAttrs",
-			log: func(l *slog.Logger) {
-				l.With("a", "b").Info("with attrs", "k", "v")
+			log: func(l *slog.Logger, worker, log int) {
+				l.With("a", "b").Info("with attrs", "worker", worker, "log", log)
 			},
 		},
 		{
 			name: "WithGroupAndAttrs",
-			log: func(l *slog.Logger) {
-				l.WithGroup("g").With("a", "b").Info("with group and attrs", "k", "v")
+			log: func(l *slog.Logger, worker, log int) {
+				l.WithGroup("g").With("a", "b").Info("with group and attrs", "worker", worker, "log", log)
 			},
 		},
 	}
@@ -668,25 +670,25 @@ func TestSlogHandler_ConcurrentLogs(t *testing.T) {
 			// - ready: indicates when all workers should start logging.
 			// - done: indicates when all workers have finished logging.
 			var ready, done sync.WaitGroup
+			ready.Add(NumWorkers)
+			done.Add(NumWorkers)
 
-			ready.Add(workers)
-			done.Add(workers)
-			for range workers {
+			for i := range NumWorkers {
 				go func() {
 					defer done.Done()
 
 					ready.Done() // I'm ready.
 					ready.Wait() // Are others?
 
-					for range logs {
-						tt.log(logger)
+					for j := range NumLogs {
+						tt.log(logger, i, j)
 					}
 				}()
 			}
 
 			done.Wait()
 
-			if got, want := strings.Count(decodeIfBinaryToString(out.Bytes()), "\n"), workers*logs; got != want {
+			if got, want := strings.Count(decodeIfBinaryToString(out.Bytes()), "\n"), NumWorkers*NumLogs; got != want {
 				t.Errorf("number of logs, got: %d, want: %d", got, want)
 			}
 		})

--- a/slog_test.go
+++ b/slog_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"runtime"
 	"strconv"
@@ -17,71 +18,7 @@ import (
 	"time"
 )
 
-func TestNewSlogHandler(t *testing.T) {
-	t.Run("no hooks", func(t *testing.T) {
-		h := NewSlogHandler(New(io.Discard))
-		if h.hasTimestampHook {
-			t.Error("hasTimestampHook, got: true, want: false")
-		}
-		if h.hasCallerHook {
-			t.Error("hasCallerHook, got: true, want: false")
-		}
-		if got, want := len(h.logger.hooks), 0; got != want {
-			t.Errorf("hooks len, got: %d, want: %d", got, want)
-		}
-	})
-
-	t.Run("timestamp hook stripped", func(t *testing.T) {
-		h := NewSlogHandler(New(io.Discard).With().Timestamp().Logger())
-		if !h.hasTimestampHook {
-			t.Error("hasTimestampHook, got: false, want: true")
-		}
-		if got, want := len(h.logger.hooks), 0; got != want {
-			t.Errorf("hooks len, got: %d, want: %d", got, want)
-		}
-	})
-
-	t.Run("caller hook stripped", func(t *testing.T) {
-		h := NewSlogHandler(New(io.Discard).With().Caller().Logger())
-		if !h.hasCallerHook {
-			t.Error("hasCallerHook, got: false, want: true")
-		}
-		if got, want := len(h.logger.hooks), 0; got != want {
-			t.Errorf("hooks len, got: %d, want: %d", got, want)
-		}
-	})
-
-	t.Run("other hooks preserved", func(t *testing.T) {
-		logger := New(io.Discard).With().Timestamp().Caller().Logger().Hook(HookFunc(func(e *Event, level Level, msg string) {}))
-		h := NewSlogHandler(logger)
-		if !h.hasTimestampHook {
-			t.Error("hasTimestampHook, got: false, want: true")
-		}
-		if !h.hasCallerHook {
-			t.Error("hasCallerHook, got: false, want: true")
-		}
-		if got, want := len(h.logger.hooks), 1; got != want {
-			t.Errorf("hooks len, got: %d, want: %d", got, want)
-		}
-	})
-
-	t.Run("original logger not mutated", func(t *testing.T) {
-		logger := New(io.Discard).With().Timestamp().Caller().Logger()
-		before := len(logger.hooks)
-		NewSlogHandler(logger)
-		if got, want := len(logger.hooks), before; got != want {
-			t.Errorf("original logger hooks mutated, got: %d, want: %d", got, want)
-		}
-	})
-}
-
 func TestSlogHandler_Enabled(t *testing.T) {
-	origGlobalLevel := GlobalLevel()
-	SetGlobalLevel(DebugLevel)
-	t.Cleanup(func() {
-		SetGlobalLevel(origGlobalLevel)
-	})
-
 	tests := []struct {
 		name        string
 		loggerLevel Level
@@ -97,24 +34,46 @@ func TestSlogHandler_Enabled(t *testing.T) {
 		{"Disabled/slog.LevelInfo", Disabled, slog.LevelInfo, false},
 		{"Disabled/slog.LevelWarn", Disabled, slog.LevelWarn, false},
 		{"Disabled/slog.LevelError", Disabled, slog.LevelError, false},
-		{"Global_DebugLevel/TraceLevel/slog.LevelDebug-2", TraceLevel, slog.LevelDebug - 2, false},
+		{"Disabled/math.MaxInt", Disabled, math.MaxInt, false},
+		{"TraceLevel/math.MinInt", TraceLevel, math.MinInt, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewSlogHandler(New(io.Discard).Level(tt.loggerLevel))
 			if got, want := h.Enabled(context.Background(), tt.level), tt.want; got != want {
-				t.Errorf("SlogHandler.Enabled, got: %v, want: %v", got, want)
+				t.Errorf("SlogHandler.Enabled() got = %v, want %v", got, want)
 			}
 		})
 	}
-}
 
-func TestSlogHandler_EnabledNilWriter(t *testing.T) {
-	h := NewSlogHandler(Logger{})
-	if got, want := h.Enabled(context.Background(), slog.LevelError), false; got != want {
-		t.Errorf("SlogHandler.Enabled, got: %v, want: %v", got, want)
-	}
+	t.Run("GlobalLevel", func(t *testing.T) {
+		origGlobalLevel := GlobalLevel()
+		SetGlobalLevel(WarnLevel)
+		t.Cleanup(func() {
+			SetGlobalLevel(origGlobalLevel)
+		})
+		h := NewSlogHandler(New(io.Discard).Level(InfoLevel))
+		if h.Enabled(context.Background(), slog.LevelInfo) {
+			t.Error("SlogHandler.Enabled() got = true, want false")
+		}
+	})
+
+	t.Run("Zero Logger (Nil Writer)", func(t *testing.T) {
+		h := NewSlogHandler(Logger{})
+		if h.Enabled(context.Background(), slog.LevelInfo) {
+			t.Error("SlogHandler.Enabled() got = true, want false")
+		}
+	})
+
+	t.Run("Nil Context", func(t *testing.T) {
+		h := NewSlogHandler(New(io.Discard).Level(InfoLevel))
+		// passing `nil` where a context is wanted is against
+		// the rules, but people still do it.
+		if !h.Enabled(nil, slog.LevelInfo) {
+			t.Error("SlogHandler.Enabled() got = false, want true")
+		}
+	})
 }
 
 func TestSlogHandler_LevelMapping(t *testing.T) {
@@ -123,6 +82,7 @@ func TestSlogHandler_LevelMapping(t *testing.T) {
 		level slog.Level
 		want  string
 	}{
+		{"math.MinInt", math.MinInt, `{"level":"trace","message":"msg"}` + "\n"},
 		{"below debug", slog.LevelDebug - 2, `{"level":"trace","message":"msg"}` + "\n"},
 		{"debug", slog.LevelDebug, `{"level":"debug","message":"msg"}` + "\n"},
 		{"between debug and info", slog.LevelInfo - 2, `{"level":"debug","message":"msg"}` + "\n"},
@@ -132,6 +92,7 @@ func TestSlogHandler_LevelMapping(t *testing.T) {
 		{"between warn and error", slog.LevelError - 2, `{"level":"warn","message":"msg"}` + "\n"},
 		{"error", slog.LevelError, `{"level":"error","message":"msg"}` + "\n"},
 		{"above error", slog.LevelError + 2, `{"level":"error","message":"msg"}` + "\n"},
+		{"math.MaxInt", math.MaxInt, `{"level":"error","message":"msg"}` + "\n"},
 	}
 
 	for _, tt := range tests {
@@ -149,8 +110,11 @@ func TestSlogHandler_LevelMapping(t *testing.T) {
 func TestSlogHandler_Timestamp(t *testing.T) {
 	t.Run("no timestamp hook omits timestamp field", func(t *testing.T) {
 		out := &bytes.Buffer{}
-		logger := slog.New(NewSlogHandler(New(out)))
-		logger.Info("msg")
+		h := NewSlogHandler(New(out))
+		record := slog.NewRecord(time.Date(2001, time.February, 3, 4, 5, 6, 7, time.UTC), slog.LevelInfo, "msg", 0)
+		if err := h.Handle(context.Background(), record); err != nil {
+			t.Fatal(err)
+		}
 		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","message":"msg"}`+"\n"; got != want {
 			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 		}
@@ -297,11 +261,35 @@ func TestSlogHandler_Message(t *testing.T) {
 	})
 }
 
+func TestSlogHandler_NilContext(t *testing.T) {
+	out := &bytes.Buffer{}
+	h := NewSlogHandler(New(out))
+	record := slog.NewRecord(time.Time{}, slog.LevelInfo, "msg", 0)
+	// passing `nil` where a context is wanted is against
+	// the rules, but people still do it.
+	if err := h.Handle(nil, record); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","message":"msg"}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestSlogHandler_ZeroRecord(t *testing.T) {
+	out := &bytes.Buffer{}
+	h := NewSlogHandler(New(out))
+	if err := h.Handle(context.Background(), slog.Record{}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info"}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
 type testCtxKey struct{}
 
 func TestSlogHandler_PropagatesContext(t *testing.T) {
 	ctx := context.WithValue(context.Background(), testCtxKey{}, "v")
-
 	hook := HookFunc(func(e *Event, level Level, message string) {
 		ctx := e.GetCtx()
 		if ctx == nil {
@@ -311,7 +299,6 @@ func TestSlogHandler_PropagatesContext(t *testing.T) {
 			e.Str("k", v)
 		}
 	})
-
 	out := &bytes.Buffer{}
 	logger := slog.New(NewSlogHandler(New(out).Hook(hook)))
 	logger.InfoContext(ctx, "msg")
@@ -339,7 +326,6 @@ func TestSlogHandler_AttrsTypes(t *testing.T) {
 	}{
 		{"zero attr", []any{slog.Attr{}}, `{"level":"info","message":"msg"}` + "\n"},
 		{"empty key", []any{"", "v"}, `{"level":"info","":"v","message":"msg"}` + "\n"},
-		{"empty group", []any{slog.Group("g")}, `{"level":"info","message":"msg"}` + "\n"},
 		{"basic types", []any{
 			"string", "hello",
 			"int64", -1,
@@ -349,10 +335,16 @@ func TestSlogHandler_AttrsTypes(t *testing.T) {
 			"time", time.Date(2001, time.February, 3, 4, 5, 6, 7, time.UTC),
 			"duration", time.Second,
 		}, `{"level":"info","string":"hello","int64":-1,"uint64":1,"float64":3.14,"bool":true,"time":"2001-02-03T04:05:06Z","duration":1000,"message":"msg"}` + "\n"},
-		{"group", []any{slog.Group("g", "k", "v")}, `{"level":"info","g":{"k":"v"},"message":"msg"}` + "\n"},
-		{"empty group name", []any{slog.Group("", "k", "v")}, `{"level":"info","k":"v","message":"msg"}` + "\n"},
-		{"nested group", []any{slog.Group("g1", slog.Group("g2", "k", "v"))}, `{"level":"info","g1":{"g2":{"k":"v"}},"message":"msg"}` + "\n"},
 		{"slog.LogValuer", []any{"k", &testLogValuer{"v"}}, `{"level":"info","k":"v","message":"msg"}` + "\n"},
+		{"group", []any{slog.Group("g", "k", "v")}, `{"level":"info","g":{"k":"v"},"message":"msg"}` + "\n"},
+		{"empty group", []any{slog.Group("g")}, `{"level":"info","message":"msg"}` + "\n"},
+		{"empty group name", []any{slog.Group("", "k", "v")}, `{"level":"info","k":"v","message":"msg"}` + "\n"},
+		{"zero attrs in group", []any{slog.Group("g", slog.Attr{}, slog.Attr{})}, `{"level":"info","message":"msg"}` + "\n"},
+		{"mixed nonzero and zero attrs in group", []any{slog.Group("g", slog.Attr{}, slog.String("k", "v"), slog.Attr{})}, `{"level":"info","g":{"k":"v"},"message":"msg"}` + "\n"},
+		{"mixed nonzero and zero attrs in group (with empty group name)", []any{slog.Group("", slog.Attr{}, slog.String("k", "v"), slog.Attr{})}, `{"level":"info","k":"v","message":"msg"}` + "\n"},
+		{"nested groups", []any{slog.Group("g1", slog.Group("g2", "k", "v"))}, `{"level":"info","g1":{"g2":{"k":"v"}},"message":"msg"}` + "\n"},
+		{"nested empty groups", []any{slog.Group("g1", slog.Group("g2"))}, `{"level":"info","message":"msg"}` + "\n"},
+		{"nested empty group names", []any{slog.Group("", "a", "b", slog.Group("", "c", "d"))}, `{"level":"info","a":"b","c":"d","message":"msg"}` + "\n"},
 		{"slog.LogValuer in group", []any{slog.Group("g", "k", &testLogValuer{"v"})}, `{"level":"info","g":{"k":"v"},"message":"msg"}` + "\n"},
 		{"any", []any{"user", testAny{Name: "john"}}, `{"level":"info","user":{"name":"john"},"message":"msg"}` + "\n"},
 		{"other types", []any{
@@ -528,23 +520,56 @@ func TestSlogHandler_WithGroupAndAttrs(t *testing.T) {
 		}
 	})
 
-	t.Run("WithAttrs/WithGroup/WithAttrs", func(t *testing.T) {
+	t.Run("chained", func(t *testing.T) {
 		out := &bytes.Buffer{}
-		logger := slog.New(NewSlogHandler(New(out))).With("a", "b").WithGroup("g").With("c", "d")
+		logger := slog.New(NewSlogHandler(New(out))).WithGroup("g1").With("a", "b").WithGroup("g2").With("c", "d").WithGroup("g3")
 		logger.Info("msg", "k", "v")
-		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","a":"b","g":{"c":"d","k":"v"},"message":"msg"}`+"\n"; got != want {
+		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","g1":{"a":"b","g2":{"c":"d","g3":{"k":"v"}}},"message":"msg"}`+"\n"; got != want {
 			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 		}
 	})
+}
 
-	t.Run("WithGroup/WithAttrs/WithGroup", func(t *testing.T) {
-		out := &bytes.Buffer{}
-		logger := slog.New(NewSlogHandler(New(out))).WithGroup("g1").With("a", "b").WithGroup("g2")
-		logger.Info("msg", "k", "v")
-		if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","g1":{"a":"b","g2":{"k":"v"}},"message":"msg"}`+"\n"; got != want {
-			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
-		}
-	})
+func TestSlogHandler_ZeroAttrsAndEmptyGroup(t *testing.T) {
+	none := func(l *slog.Logger) *slog.Logger { return l }
+	group := func(l *slog.Logger) *slog.Logger { return l.WithGroup("g") }
+	nestedGroup := func(l *slog.Logger) *slog.Logger { return l.WithGroup("g1").With("a", "b").WithGroup("g2") }
+
+	tests := []struct {
+		name string
+		with func(*slog.Logger) *slog.Logger
+		args []any
+		want string
+	}{
+		{"empty group", group, []any{slog.Attr{}, slog.Group("x")}, `{"level":"info","message":"msg"}` + "\n"},
+		{"nonempty group", group, []any{slog.Attr{}, "a", "b", slog.Group("x"), slog.Group("y", "c", "d")}, `{"level":"info","g":{"a":"b","y":{"c":"d"}},"message":"msg"}` + "\n"},
+		{"empty group with empty group name", none, []any{slog.Attr{}, slog.Group("x")}, `{"level":"info","message":"msg"}` + "\n"},
+		{"nonempty group with empty group name", none, []any{slog.Attr{}, "a", "b", slog.Group("x"), slog.Group("y", "c", "d")}, `{"level":"info","a":"b","y":{"c":"d"},"message":"msg"}` + "\n"},
+		{"empty nested group", nestedGroup, []any{slog.Attr{}, slog.Group("x")}, `{"level":"info","g1":{"a":"b"},"message":"msg"}` + "\n"},
+		{"non empty nested group", nestedGroup, []any{slog.Attr{}, "c", "d", slog.Group("x")}, `{"level":"info","g1":{"a":"b","g2":{"c":"d"}},"message":"msg"}` + "\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run("RecordAttrs/"+tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			logger := slog.New(NewSlogHandler(New(out)))
+			logger = tt.with(logger)
+			logger.Info("msg", tt.args...)
+			if got, want := decodeIfBinaryToString(out.Bytes()), tt.want; got != want {
+				t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+			}
+		})
+
+		t.Run("WithAttrs/"+tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			logger := slog.New(NewSlogHandler(New(out)))
+			logger = tt.with(logger)
+			logger.With(tt.args...).Info("msg")
+			if got, want := decodeIfBinaryToString(out.Bytes()), tt.want; got != want {
+				t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+			}
+		})
+	}
 }
 
 func TestSlogHandler_WithSampler(t *testing.T) {
@@ -562,27 +587,21 @@ func TestSlogHandler_WithSampler(t *testing.T) {
 
 func TestSlogHandler_WithZerologContext(t *testing.T) {
 	tests := []struct {
-		name     string
-		group    string
-		withArgs []any
-		logArgs  []any
-		want     string
+		name  string
+		group string
+		args  []any
+		want  string
 	}{
-		{"Empty/Empty/Empty", "", nil, nil, `{"level":"info","k":"v","message":"msg"}` + "\n"},
-		{"Empty/Empty/Attrs", "", nil, []any{"k1", "v1"}, `{"level":"info","k":"v","k1":"v1","message":"msg"}` + "\n"},
-		{"Empty/WithAttrs/Empty", "", []any{"k1", "v1"}, nil, `{"level":"info","k":"v","k1":"v1","message":"msg"}` + "\n"},
-		{"Empty/WithAttrs/Attrs", "", []any{"k1", "v1"}, []any{"k2", "v2"}, `{"level":"info","k":"v","k1":"v1","k2":"v2","message":"msg"}` + "\n"},
-		{"Group/Empty/Empty", "g", nil, nil, `{"level":"info","k":"v","message":"msg"}` + "\n"},
-		{"Group/Empty/Attrs", "g", nil, []any{"k1", "v1"}, `{"level":"info","k":"v","g":{"k1":"v1"},"message":"msg"}` + "\n"},
-		{"Group/WithAttrs/Empty", "g", []any{"k1", "v1"}, nil, `{"level":"info","k":"v","g":{"k1":"v1"},"message":"msg"}` + "\n"},
-		{"Group/WithAttrs/Attrs", "g", []any{"k1", "v1"}, []any{"k2", "v2"}, `{"level":"info","k":"v","g":{"k1":"v1","k2":"v2"},"message":"msg"}` + "\n"},
+		{"just context", "", nil, `{"level":"info","k":"v","message":"msg"}` + "\n"},
+		{"context+group", "g", []any{"a", "b"}, `{"level":"info","k":"v","g":{"a":"b"},"message":"msg"}` + "\n"},
+		{"context+attrs", "", []any{"a", "b"}, `{"level":"info","k":"v","a":"b","message":"msg"}` + "\n"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
-			logger := slog.New(NewSlogHandler(New(out).With().Str("k", "v").Logger())).WithGroup(tt.group).With(tt.withArgs...)
-			logger.Info("msg", tt.logArgs...)
+			logger := slog.New(NewSlogHandler(New(out).With().Str("k", "v").Logger())).WithGroup(tt.group)
+			logger.Info("msg", tt.args...)
 			if got, want := decodeIfBinaryToString(out.Bytes()), tt.want; got != want {
 				t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 			}
@@ -594,11 +613,18 @@ func TestSlogHandler_WithHook(t *testing.T) {
 	called := false
 	hook := HookFunc(func(e *Event, level Level, msg string) {
 		called = true
+		e.Str("k", "v")
 	})
-	logger := slog.New(NewSlogHandler(New(io.Discard).Hook(hook)))
+
+	out := &bytes.Buffer{}
+	logger := slog.New(NewSlogHandler(New(out).Hook(hook))).WithGroup("g").With("a", "b")
 	logger.Info("msg")
+
 	if !called {
 		t.Error("called, got: false, want: true")
+	}
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"info","g":{"a":"b"},"k":"v","message":"msg"}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
 }
 
@@ -674,7 +700,7 @@ func TestSlogHandler_ConcurrentLogs(t *testing.T) {
 			done.Wait()
 
 			if got, want := strings.Count(decodeIfBinaryToString(out.Bytes()), "\n"), NumWorkers*NumLogs; got != want {
-				t.Errorf("number of logs, got: %d, want: %d", got, want)
+				t.Errorf("number of logs = %d, want: %v", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
# Rewrite SlogHandler for spec-compliant timestamps, callers, and groups

Fixes #787 

## Description

Rewrite `SlogHandler` (`slog.go`, `slog_test.go`) based on the "pre-formatting handler" pattern from this official [handler writing guide](https://github.com/golang/example/blob/master/slog-handler-guide/README.md), the `slog.Handler` [spec](https://pkg.go.dev/log/slog#Handler) and the [`slog.commonHandler`](https://cs.opensource.google/go/go/+/master:src/log/slog/handler.go;drc=97b2becb4e70a53df1816a9ed350f33c612a43a3;l=191) implementation.

It fixes all the issues and contract violations described in #787 , and `SlogHandler` now passes the standard library's own `testing/slogtest` conformance suite.

## Breaking changes

No API breaking changes — the new implementation doesn't change any public API for the `zerolog` package or `SlogHandler`.

The log output of `SlogHandler` changes, but the new version is more correct and consistent with zerolog's own logging structure. The old implementation used a completely different format (flattened keys instead of a JSON object) compared to `Logger`'s own output.

Changes are isolated to `slog.go` and `slog_test.go`. Since this is a new implementation of `SlogHandler` that changes how it works under the hood, `slog_test.go` was rewritten from scratch.

## Design decisions

### 1. Stripping the Timestamp and Caller hooks

When `NewSlogHandler` is called with a `Logger`, the `Timestamp()` and `Caller()` hooks are stripped from the logger's hook list, and the handler remembers whether the logger had these hooks. When `SlogHandler.Handle` is called, the timestamp and caller are sourced from the `slog.Record` if the respective hooks were present on the logger, using the same formatting `Event` would apply.

This lets the handler drop the timestamp and caller when the corresponding value on the record is zero (per the slog spec), and lets it resolve the actual call site for the log entry.

People using custom hooks for timestamp or caller are unaffected by this change — their hooks still work as before, and there's no duplicate timestamp/caller, since the handler only adds its own when the `Timestamp()`/`Caller()` hooks are present on the logger.

### 2. Using `Context` for pre-formatting

This `SlogHandler` implementation uses `Context` and `Context.l.context` (the `Logger`'s underlying context buffer, obtained via `Logger.With`) for pre-formatting attrs and groups.

When `WithAttrs` is called, all unopened groups are opened directly in `Context.l.context` using the `enc` encoder. Since this is done after calling `Logger.With`, it doesn't affect the parent logger. All attrs are appended to `Context` using `appendSlogAttrToContext`.

`appendSlogAttrToContext` and `appendSlogAttrToEvent` are effectively the same function — one operates on `Event`, the other on `Context` — mirroring how most methods in `event.go` and `context.go` come in matching pairs.

### 3. Opening and closing groups in the context and event buffers

One of the main pain points in implementing `SlogHandler` has been that when `WithGroup` is called, all attrs added afterward need to be nested inside that group. Since zerolog didn't already have anything like this, it needed to be implemented without introducing any breaking changes.

I chose to open a group the moment its first attr is encountered, either in `WithAttrs` or `Handle`. Groups are opened in `Context.l.context` or `Event.buf` respectively, using the `enc` encoder. Because each `SlogHandler` stores its own `Logger` in an internal field, and `WithAttrs`/`WithGroup` return a new `SlogHandler` wrapping a copied `Logger`, a given `Logger`/`Event` is isolated from any other call path — so a group left open on one path can never leak into another's output.

Groups are closed in `Handle` once all of the record's attrs have been added to the `Event`. After closing all the groups, the timestamp, caller, and message are added to the `Event`. Since all groups are closed before `Event.Msg` is called, hooks — which fire inside `Msg` — never see a group left open in the buffer.

Since attrs of `slog.KindGroup` are added to the buffer using `Event`/`Context`'s `Dict()` method, this part of the implementation is straightforward.

### 4. Dropping empty groups using buffer rollback

A group can still be empty even if `len(attrs) > 0`. This can happen when the attrs consist only of zero attrs and empty groups. These cases cannot be detected before looping through all attrs. So, I chose to use the buffer rollback pattern from [`slog.commonHandler`](https://cs.opensource.google/go/go/+/master:src/log/slog/handler.go;drc=97b2becb4e70a53df1816a9ed350f33c612a43a3;l=191) implementation to handle this edge case.

Before opening the groups, the current buffer position is remembered as `pos := len(buf)`. After applying the attrs, if the group turns out to be empty, the buffer is rolled back via `buf = buf[:pos]`. `appendSlogAttrToContext`/`appendSlogAttrToEvent` return a bool that is true if attrs were added to the `Event`/`Context`; this is used to decide whether to roll back the opened group.

Attrs of `slog.KindGroup` are added via `Dict()`; if a group's dict turns out empty, it's discarded and returned to the pool instead of being attached.

### 5. Expanding the `slog.KindAny` switch cases to avoid reflection where possible

I expanded the `slog.KindAny` branch in `appendSlogAttrToContext`/`appendSlogAttrToEvent` to cover more of the types zerolog already supports natively, avoiding reflection and using zerolog's own encoder wherever possible.

## Issues fixed (numbered per the linked issue)

### 1 & 2. Groups now correctly render as nested JSON objects instead of flattened keys, and attrs are nested at the level where they were actually added. (See design decisions 2 & 3.)

#### Tests:

- [`TestSlogHandler_WithGroup`](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L398)

- [`TestSlogHandler_WithAttrs`](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L463)

- [`TestSlogHandler_WithGroupAndAttrs`](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L504)

### 3 & 4. The timestamp is now sourced from `record.Time`, and omitted when `record.Time` is zero.

#### Tests:

- [`TestSlogHandler_Timestamp`](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L110)

### 5. The timestamp and caller are logged only if logger is configured with `Timestamp()` and `Caller()` respectively.

This prevents log inconsistency and avoids producing a duplicate time field when a custom timestamp hook is used.

#### Tests:

- [`TestSlogHandler_Timestamp/no timestamp hook omits timestamp field`](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L111)

- [`TestSlogHandler_Caller/no caller hook omits caller field`](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L164)

### 6 & 7. The caller is now sourced from `record.PC`, and omitted when `record.PC` is zero.

#### Tests:

- [`TestSlogHandler_Caller`](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L163)

### 8. Empty attrs are now identified via `slog.Attr.Equal(slog.Attr{})` instead of a bare key check, so values with an empty key are no longer dropped.

#### Tests:

- [`TestSlogHandler_AttrsTypes`](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L321)

### 9. The new handler uses `Context` for pre-formatted groups and attrs. (See design decision 2.)

### 10. This handler passes the official `testing/slogtest` conformance suite.

#### Tests:

- [`TestSlogHandler_Slogtest`](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L709)

```
$ go test -v -run TestSlogHandler_Slogtest
=== RUN   TestSlogHandler_Slogtest
--- PASS: TestSlogHandler_Slogtest (0.00s)
PASS
ok      github.com/rs/zerolog   0.003s
```

### 11. Fixed tests

- Fixes the scenario `TestSlogHandler_EmptyMessage` was meant to cover; it's now the `"empty message omits message field"` subtest of `TestSlogHandler_Message` — [here](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L233)

- Fixes the scenario `TestSlogHandler_WithAttrsImmutability` was meant to cover; it's now the `"original handler not mutated"` subtest of `TestSlogHandler_WithAttrs` — [here](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L474)

- Fixes the scenario `TestSlogHandler_EnabledNilWriter` was meant to cover; it's now the `"Zero Logger (Nil Writer)"` subtest of `TestSlogHandler_Enabled` — [here](https://github.com/anuragkumar19/zerolog/blob/ebe1ecbc792a6cda5cfa0b9d2c9cf3e006bca5f4/slog_test.go#L62)

### Other issues (1 & 2). Fixed.

`slog_test.go` now uses `package zerolog`, and all tests use `decodeIfBinaryToBytes`/`decodeIfBinaryToString`. Testing is now done with byte-for-byte log comparison instead of `json.Unmarshal`.

## Complete module test

Ran the full suite, including the `binary_log` build tag:

```
$ go test -race ./...
ok      github.com/rs/zerolog   1.099s
?       github.com/rs/zerolog/cmd/prettylog     [no test files]
ok      github.com/rs/zerolog/diode     (cached)
?       github.com/rs/zerolog/diode/internal/diodes     [no test files]
ok      github.com/rs/zerolog/hlog      (cached)
?       github.com/rs/zerolog/hlog/internal/mutil       [no test files]
?       github.com/rs/zerolog/internal  [no test files]
ok      github.com/rs/zerolog/internal/cbor     (cached)
?       github.com/rs/zerolog/internal/cbor/examples    [no test files]
ok      github.com/rs/zerolog/internal/json     (cached)
ok      github.com/rs/zerolog/journald  (cached)
ok      github.com/rs/zerolog/log       (cached)
ok      github.com/rs/zerolog/pkgerrors (cached)
$ go test -race -tags binary_log ./...
ok      github.com/rs/zerolog   1.159s
?       github.com/rs/zerolog/cmd/prettylog     [no test files]
ok      github.com/rs/zerolog/diode     (cached)
?       github.com/rs/zerolog/diode/internal/diodes     [no test files]
ok      github.com/rs/zerolog/hlog      (cached)
?       github.com/rs/zerolog/hlog/internal/mutil       [no test files]
?       github.com/rs/zerolog/internal  [no test files]
ok      github.com/rs/zerolog/internal/cbor     (cached)
?       github.com/rs/zerolog/internal/cbor/examples    [no test files]
ok      github.com/rs/zerolog/internal/json     (cached)
ok      github.com/rs/zerolog/journald  (cached)
?       github.com/rs/zerolog/log       [no test files]
?       github.com/rs/zerolog/pkgerrors [no test files]
```
