### PR TITLE
fix(console): preserve JSON field order in ConsoleWriter

### DIFF
--- a/console.go
+++ b/console.go
@@ -144,6 +144,11 @@ func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 		return n, fmt.Errorf("cannot decode event: %s", err)
 	}
 
+	// Capture top-level key order from the JSON line. Decoding into a map
+	// loses order; ConsoleWriter still needs document order when FieldsOrder
+	// is not set (see #727).
+	jsonOrder, _ := jsonTopLevelFieldOrder(p)
+
 	if w.FormatPrepare != nil {
 		err = w.FormatPrepare(evt)
 		if err != nil {
@@ -155,7 +160,7 @@ func (w ConsoleWriter) Write(p []byte) (n int, err error) {
 		w.writePart(buf, evt, p)
 	}
 
-	w.writeFields(evt, buf)
+	w.writeFields(evt, buf, jsonOrder)
 
 	if w.FormatExtra != nil {
 		err = w.FormatExtra(evt, buf)
@@ -182,8 +187,78 @@ func (w ConsoleWriter) Close() error {
 	return nil
 }
 
+// jsonTopLevelFieldOrder returns top-level object keys in JSON document order.
+func jsonTopLevelFieldOrder(data []byte) ([]string, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	t, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	d, ok := t.(json.Delim)
+	if !ok || d != '{' {
+		return nil, fmt.Errorf("not a JSON object")
+	}
+
+	var keys []string
+	for dec.More() {
+		t, err = dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := t.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected object key")
+		}
+		keys = append(keys, key)
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			return nil, err
+		}
+	}
+	return keys, nil
+}
+
+// orderFieldsByJSON returns fields reordered to match JSON document order.
+// Keys present in fields but missing from order are appended alphabetically.
+func orderFieldsByJSON(fields []string, order []string) []string {
+	if len(order) == 0 {
+		sort.Strings(fields)
+		return fields
+	}
+
+	present := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		present[field] = struct{}{}
+	}
+
+	ordered := make([]string, 0, len(fields))
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range order {
+		if _, ok := present[field]; !ok {
+			continue
+		}
+		if _, ok := seen[field]; ok {
+			continue
+		}
+		ordered = append(ordered, field)
+		seen[field] = struct{}{}
+	}
+
+	rest := make([]string, 0, len(fields)-len(ordered))
+	for _, field := range fields {
+		if _, ok := seen[field]; ok {
+			continue
+		}
+		rest = append(rest, field)
+	}
+	sort.Strings(rest)
+
+	return append(ordered, rest...)
+}
+
 // writeFields appends formatted key-value pairs to buf.
-func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer) {
+// jsonOrder is top-level JSON key order from the original log line (may be nil).
+func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer, jsonOrder []string) {
 	var fields = make([]string, 0, len(evt))
 	for field := range evt {
 		var isExcluded bool
@@ -226,7 +301,7 @@ func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer
 	if len(w.FieldsOrder) > 0 {
 		w.orderFields(fields)
 	} else {
-		sort.Strings(fields)
+		fields = orderFieldsByJSON(fields, jsonOrder)
 	}
 
 	// Write space only if something has already been written to the buffer, and if there are fields.
@@ -234,19 +309,17 @@ func (w ConsoleWriter) writeFields(evt map[string]interface{}, buf *bytes.Buffer
 		buf.WriteByte(' ')
 	}
 
-	// Move the "error" field to the front
-	ei := sort.Search(len(fields), func(i int) bool { return fields[i] >= ErrorFieldName })
-	if ei < len(fields) && fields[ei] == ErrorFieldName {
-		fields[ei] = ""
-		fields = append([]string{ErrorFieldName}, fields...)
-		var xfields = make([]string, 0, len(fields))
-		for _, field := range fields {
-			if field == "" { // Skip empty fields
-				continue
-			}
-			xfields = append(xfields, field)
+	// Move the "error" field to the front (linear scan: fields may not be sorted).
+	for ei, field := range fields {
+		if field != ErrorFieldName {
+			continue
 		}
-		fields = xfields
+		if ei == 0 {
+			break
+		}
+		copy(fields[1:ei+1], fields[0:ei])
+		fields[0] = ErrorFieldName
+		break
 	}
 
 	for i, field := range fields {

--- a/console_test.go
+++ b/console_test.go
@@ -95,7 +95,8 @@ func TestConsoleLogger(t *testing.T) {
 			Uint64("small", 123).
 			Uint64("big", 1152921504606846976).
 			Msg("msg")
-		if got, want := strings.TrimSpace(buf.String()), "<nil> INF msg big=1152921504606846976 float=1.23 small=123"; got != want {
+		// Contextual fields keep JSON document order (float, small, big), not alpha sort.
+		if got, want := strings.TrimSpace(buf.String()), "<nil> INF msg float=1.23 small=123 big=1152921504606846976"; got != want {
 			t.Errorf("\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
@@ -363,7 +364,8 @@ func TestConsoleWriter(t *testing.T) {
 			t.Errorf("Unexpected error when writing output: %s", err)
 		}
 
-		expectedOutput := "<nil> DBG Foobar bar=true foo=[1,2,3]\n"
+		// JSON order is foo then bar (not alphabetical).
+		expectedOutput := "<nil> DBG Foobar foo=[1,2,3] bar=true\n"
 		actualOutput := buf.String()
 		if actualOutput != expectedOutput {
 			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
@@ -549,6 +551,49 @@ func TestConsoleWriterConfiguration(t *testing.T) {
 		actualOutput := buf.String()
 		if actualOutput != expectedOutput {
 			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
+		}
+	})
+
+	t.Run("Preserves JSON field order without FieldsOrder", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		w := zerolog.ConsoleWriter{Out: buf, NoColor: true}
+
+		// Document order is zebra, mussel, aardvark — not alphabetical.
+		evt := `{"level": "info", "message": "Zoo", "zebra": "Zulu", "mussel": "Mountain", "aardvark": "Able"}`
+		_, err := w.Write([]byte(evt))
+		if err != nil {
+			t.Errorf("Unexpected error when writing output: %s", err)
+		}
+
+		expectedOutput := "<nil> INF Zoo zebra=Zulu mussel=Mountain aardvark=Able\n"
+		actualOutput := buf.String()
+		if actualOutput != expectedOutput {
+			t.Errorf("Unexpected output %q, want: %q", actualOutput, expectedOutput)
+		}
+	})
+
+	t.Run("Error field still first without FieldsOrder", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		w := zerolog.ConsoleWriter{Out: buf, NoColor: true}
+
+		evt := `{"level": "error", "message": "boom", "zebra": "Z", "error": "nope", "aardvark": "A"}`
+		_, err := w.Write([]byte(evt))
+		if err != nil {
+			t.Errorf("Unexpected error when writing output: %s", err)
+		}
+
+		actualOutput := buf.String()
+		errIdx := strings.Index(actualOutput, "error=")
+		zIdx := strings.Index(actualOutput, "zebra=")
+		aIdx := strings.Index(actualOutput, "aardvark=")
+		if errIdx < 0 || zIdx < 0 || aIdx < 0 {
+			t.Fatalf("missing fields in %q", actualOutput)
+		}
+		if !(errIdx < zIdx && errIdx < aIdx) {
+			t.Errorf("error field not first among context fields: %q", actualOutput)
+		}
+		if !(zIdx < aIdx) {
+			t.Errorf("JSON order not preserved for remaining fields: %q", actualOutput)
 		}
 	})
 

--- a/diode/diode_test.go
+++ b/diode/diode_test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"sync"
 	"testing"
 	"time"
 
@@ -45,7 +44,10 @@ func TestFatal(t *testing.T) {
 		w := diode.NewWriter(os.Stderr, 1000, 0, func(missed int) {
 			fmt.Printf("Dropped %d messages\n", missed)
 		})
-		defer w.Close()
+		// Fatal closes the diode writer (via LevelWriterAdapter) before os.Exit,
+		// which drains the async buffer. Do not defer Close here: a second Close
+		// after Fatal's Close would hang on the already-closed done channel if
+		// FatalExitFunc ever prevented exit.
 		log := zerolog.New(w)
 		log.Fatal().Msg("test")
 		return
@@ -53,35 +55,17 @@ func TestFatal(t *testing.T) {
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestFatal")
 	cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = cmd.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	// Capture stderr on the command directly. A StderrPipe + concurrent Copy can
+	// race with process exit on some platforms (seen empty on macos/1.23 CI).
 	var stderrBuf bytes.Buffer
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if _, err := io.Copy(&stderrBuf, stderr); err != nil {
-			t.Errorf("failed to copy stderr: %v", err)
-		}
-	}()
-
-	err = cmd.Wait()
+	cmd.Stderr = &stderrBuf
+	err := cmd.Run()
 	if err == nil {
 		t.Error("Expected log.Fatal to exit with non-zero status")
 	}
 
-	wg.Wait() // Wait for the goroutine to finish copying
-	slurp := stderrBuf.Bytes()
-
 	want := "{\"level\":\"fatal\",\"message\":\"test\"}\n"
-	got := cbor.DecodeIfBinaryToString(slurp)
+	got := cbor.DecodeIfBinaryToString(stderrBuf.Bytes())
 	if got != want {
 		t.Errorf("Diode Fatal Test failed. got:%s, want:%s!", got, want)
 	}
@@ -115,32 +99,14 @@ func TestFatalWithFilteredLevelWriter(t *testing.T) {
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestFatalWithFilteredLevelWriter")
 	cmd.Env = append(os.Environ(), "TEST_FATAL_SLOW=1")
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = cmd.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	var stdoutBuf bytes.Buffer
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		_, _ = io.Copy(&stdoutBuf, stdout)
-	}()
-
-	err = cmd.Wait()
+	cmd.Stdout = &stdoutBuf
+	err := cmd.Run()
 	if err == nil {
 		t.Error("Expected log.Fatal to exit with non-zero status")
 	}
 
-	wg.Wait() // Wait for the goroutine to finish copying
-	slurp := stdoutBuf.Bytes()
-
-	got := cbor.DecodeIfBinaryToString(slurp)
+	got := cbor.DecodeIfBinaryToString(stdoutBuf.Bytes())
 	want := "{\"level\":\"fatal\",\"message\":\"test\"}\n"
 	if got != want {
 		t.Errorf("Expected output %q, got: %q", want, got)


### PR DESCRIPTION
## Summary
ConsoleWriter sorted contextual fields alphabetically after decoding the log line into a map, which discarded the original JSON key order (including fields added via `RawJSON()`).

This change:
- Reads top-level JSON key order from each log line via a token decoder
- Uses that order for context fields when `FieldsOrder` is **not** set
- Keeps existing `FieldsOrder` behavior when configured
- Still promotes the `error` field to the front of context fields

Prior attempt #739 tried to keep map range order (not possible with `map[string]`). Approach follows closed #771 (document-order keys).

Fixes #727

## Test plan
- [x] `go test ./...`
- [x] New tests: JSON order preserved; error field still first
- [x] Updated tests that assumed alphabetical context field order