### PR TITLE
test: add TestParseLevelOutOfBounds and fix doc comment typos

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,6 +1,6 @@
 // Package zerolog provides a lightweight logging library dedicated to JSON logging.
 //
-// A global Logger can be use for simple logging:
+// A global Logger can be used for simple logging:
 //
 //	import "github.com/rs/zerolog/log"
 //
@@ -38,7 +38,7 @@
 //	if e := log.Debug(); e.Enabled() {
 //	    // Compute log output only if enabled.
 //	    value := compute()
-//	    e.Str("foo": value).Msg("some debug message")
+//	    e.Str("foo", value).Msg("some debug message")
 //	}
 //	// Output: {"level":"info","time":1494567715,"routed message"}
 //
@@ -86,8 +86,8 @@
 //
 // Field duplication:
 //
-// There is no fields deduplication out-of-the-box.
-// Using the same key multiple times creates new key in final JSON each time.
+// There is no field deduplication out-of-the-box.
+// Using the same key multiple times creates a new key in the final JSON each time.
 //
 //	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
 //	logger.Info().

--- a/log_test.go
+++ b/log_test.go
@@ -1466,3 +1466,15 @@ func TestParseLevelWarningAlias(t *testing.T) {
 		t.Fatalf("ParseLevel(WARNING)=%v %v", l, err)
 	}
 }
+
+func TestParseLevelOutOfBounds(t *testing.T) {
+	l, err := ParseLevel("128")
+	if err == nil || l != NoLevel {
+		t.Fatalf("expected error for 128, got %v (%v)", l, err)
+	}
+	l, err = ParseLevel("-129")
+	if err == nil || l != NoLevel {
+		t.Fatalf("expected error for -129, got %v (%v)", l, err)
+	}
+}
+


### PR DESCRIPTION
### Summary
- In `log_test.go`, add unit test `TestParseLevelOutOfBounds` covering `ParseLevel` behavior when given out-of-bounds numerical level strings (`"128"`, `"-129"`).
- Fix doc comment typos and syntax in code examples in `log.go` (`can be use` -> `can be used`, `e.Str("foo": value)` -> `e.Str("foo", value)`).