### PR TITLE
chore: Isolate pkgerrors and drop pkg/errors from main module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
           ${{ runner.os }}-go-
     - name: Test
       run: go test -race -bench . -benchmem ./...
+    - name: Test pkgerrors
+      run: go test -race -bench . -benchmem ./...
+      working-directory: pkgerrors
     - name: Test CBOR
       run: go test -tags binary_log -race ./...
   coverage:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.23
 require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/mattn/go-colorable v0.1.14
-	github.com/pkg/errors v0.9.1
 	github.com/rs/xid v1.6.0
 )
 

--- a/pkgerrors/go.mod
+++ b/pkgerrors/go.mod
@@ -1,0 +1,16 @@
+module github.com/rs/zerolog/pkgerrors
+
+go 1.23
+
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/rs/zerolog v1.34.0
+)
+
+require (
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	golang.org/x/sys v0.29.0 // indirect
+)
+
+replace github.com/rs/zerolog => ..

--- a/pkgerrors/go.sum
+++ b/pkgerrors/go.sum
@@ -1,11 +1,9 @@
-github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
-github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
-github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
This PR removes github.com/pkg/errors as a dependency from the main part of the library and extracts dependency on github.com/pkg/errors to an external pkg

This PR also tries to address the issue [470](https://github.com/rs/zerolog/issues/470) from the main repo