### PR TITLE
docs: fix dead bench.zerolog.io link in README benchmarks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,7 +754,7 @@ The handler supports all `slog` features including `WithAttrs`, `WithGroup`, nes
 
 ## Benchmarks
 
-See [logbench](http://bench.zerolog.io/) for more comprehensive and up-to-date benchmarks.
+See [logbench](https://github.com/rs/logbench) for more comprehensive and up-to-date benchmarks.
 
 All operations are allocation free (those numbers _include_ JSON encoding):
 


### PR DESCRIPTION
## Summary

The Benchmarks section of the README links to `http://bench.zerolog.io/`, which no longer resolves. Both Cloudflare (1.1.1.1) and Google public DNS return NXDOMAIN for that hostname, so the link is dead for every reader.

The reference points at **logbench** — the benchmark suite lives in the `rs/logbench` repository (last push 2023-08). This PR repoints the link to https://github.com/rs/logbench so the "more comprehensive and up-to-date benchmarks" pointer works again.

## Verification

- DNS: `bench.zerolog.io` → Status 3 (NXDOMAIN) via both https://1.1.1.1/dns-query and https://dns.google/resolve
- Replacement target verified live: https://github.com/rs/logbench returns 200
- Repo-wide URL sweep of README + docs (`*.md`, non-test `.go`): 31 unique URLs live-checked, this was the only non-200
- No code change: `go build ./...` and `go vet ./...` clean

## AI disclosure

This fix was identified and prepared with AI assistance under human direction and review by @CAOShurong.