### PR TITLE
fix(cbor): decode major type 0 over its full unsigned range

### DIFF
--- a/internal/cbor/decode_stream.go
+++ b/internal/cbor/decode_stream.go
@@ -44,10 +44,10 @@ func readByte(src *bufio.Reader) byte {
 	return b
 }
 
-func decodeIntAdditionalType(src *bufio.Reader, minor byte) int64 {
-	val := int64(0)
+func decodeIntAdditionalType(src *bufio.Reader, minor byte) uint64 {
+	val := uint64(0)
 	if minor <= 23 {
-		val = int64(minor)
+		val = uint64(minor)
 	} else {
 		bytesToRead := 0
 		switch minor {
@@ -65,7 +65,7 @@ func decodeIntAdditionalType(src *bufio.Reader, minor byte) int64 {
 		pb := readNBytes(src, bytesToRead)
 		for i := 0; i < bytesToRead; i++ {
 			val = val * 256
-			val += int64(pb[i])
+			val += uint64(pb[i])
 		}
 	}
 	return val
@@ -80,9 +80,22 @@ func decodeInteger(src *bufio.Reader) int64 {
 	}
 	val := decodeIntAdditionalType(src, minor)
 	if major == 0 {
-		return val
+		return int64(val)
 	}
-	return (-1 - val)
+	return (-1 - int64(val))
+}
+
+// decodeUnsignedInteger decodes a major type 0 integer over the whole range
+// RFC 8949 section 3.1 gives it, 0..2^64-1, which does not fit the int64 that
+// decodeInteger returns.
+func decodeUnsignedInteger(src *bufio.Reader) uint64 {
+	pb := readByte(src)
+	major := pb & maskOutAdditionalType
+	minor := pb & maskOutMajorType
+	if major != majorTypeUnsignedInt {
+		panic(fmt.Errorf("Major type is: %d in decodeUnsignedInteger!! (expected 0)", major))
+	}
+	return decodeIntAdditionalType(src, minor)
 }
 
 func decodeFloat(src *bufio.Reader) (float64, int) {
@@ -545,10 +558,10 @@ func cbor2JsonOneObject(src *bufio.Reader, dst io.Writer) {
 
 	switch major {
 	case majorTypeUnsignedInt:
-		fallthrough
+		dst.Write([]byte(strconv.FormatUint(decodeUnsignedInteger(src), 10)))
+
 	case majorTypeNegativeInt:
-		n := decodeInteger(src)
-		dst.Write([]byte(strconv.Itoa(int(n))))
+		dst.Write([]byte(strconv.FormatInt(decodeInteger(src), 10)))
 
 	case majorTypeByteString:
 		s := decodeString(src, false)

--- a/internal/cbor/decoder_test.go
+++ b/internal/cbor/decoder_test.go
@@ -3,7 +3,9 @@ package cbor
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +18,39 @@ func TestDecodeInteger(t *testing.T) {
 		if gotv != int64(tc.Val) {
 			t.Errorf("decodeInteger(0x%s)=0x%d, want: 0x%d",
 				hex.EncodeToString([]byte(tc.Binary)), gotv, tc.Val)
+		}
+	}
+}
+
+func TestDecodeUnsignedInteger64Bit(t *testing.T) {
+	// RFC 8949 section 3.1: major type 0 carries 0..2^64-1. Values at or above
+	// 2^63 do not fit the int64 decodeInteger returns, so they must be decoded
+	// and rendered unsigned.
+	var enc Encoder
+	for _, val := range []uint64{0, 1, math.MaxInt64, 1 << 63, math.MaxUint64} {
+		b := enc.AppendBeginMarker(nil)
+		b = enc.AppendKey(b, "k")
+		b = enc.AppendUint64(b, val)
+		b = enc.AppendEndMarker(b)
+
+		want := fmt.Sprintf("{\"k\":%d}", val)
+		got := strings.TrimSpace(DecodeIfBinaryToString(b))
+		if got != want {
+			t.Errorf("DecodeIfBinaryToString(AppendUint64(%d))=%s, want: %s", val, got, want)
+		}
+	}
+
+	// Negative integers (major type 1) keep their existing rendering.
+	for _, val := range []int64{-1, math.MinInt64} {
+		b := enc.AppendBeginMarker(nil)
+		b = enc.AppendKey(b, "k")
+		b = enc.AppendInt64(b, val)
+		b = enc.AppendEndMarker(b)
+
+		want := fmt.Sprintf("{\"k\":%d}", val)
+		got := strings.TrimSpace(DecodeIfBinaryToString(b))
+		if got != want {
+			t.Errorf("DecodeIfBinaryToString(AppendInt64(%d))=%s, want: %s", val, got, want)
 		}
 	}
 }


### PR DESCRIPTION
`AppendUint64` writes the full RFC 8949 §3.1 range for major type 0 (0..2^64-1), but `decodeIntAdditionalType` accumulated into an `int64`, so any value at or above 2^63 wrapped negative on the way back. The writer and the reader in this package disagree.

Measured end to end under `-tags binary_log`:

```go
l.Log().Uint64("k", math.MaxUint64).Send()
// before: {"k":-1}          after: {"k":18446744073709551615}
l.Log().Uint64("k", 1<<63).Send()
// before: {"k":-9223372036854775808}   after: {"k":9223372036854775808}
```

Anything below 2^63 is unaffected.

Two halves: accumulate unsigned, and render major type 0 through `FormatUint` instead of sharing the signed path by `fallthrough`. Every other caller of `decodeIntAdditionalType` already narrows the result itself (`int(length)`, `byte(val)`, `uint16(val)`), so those are unchanged. The second half also drops a `strconv.Itoa(int(n))` that truncated values outside `int32` on 32-bit builds.

Making only the accumulator unsigned is not enough — the signed render path still prints `-1`. That variant fails the new test, which is why both halves are here.

`go test ./...` and `go test -tags binary_log ./...` are clean apart from `diode.TestNewWriter`, which is a pre-existing flake: 3/12 failures on unmodified master, 2/12 with this change.

Drafted with Claude Opus 5 (`claude-opus-5`); every claim was executed.
